### PR TITLE
Implement initial Parser type to parse schema templates

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,158 @@
+import { StringJoin } from "./types/StringJoin";
+import { Trim, TrimLeft } from "./types/Trim";
+
+/**
+ * We should never be able to create a value of this type legitimately.
+ *
+ * `ErrorMessageT` is our error message
+ */
+interface CompileError<ErrorMessageT extends any[]> {
+  /**
+   * There should never be a value of this type
+   */
+  readonly __compileError: never;
+}
+
+type Key = string | number | symbol;
+
+type Resolve<T> = T extends CompileError<any>
+  ? T
+  : T extends any[]
+  ? T extends any[][]
+    ? // Is array of arrays -- resolve next level
+      Resolve<T[number]>[]
+    : T extends Record<Key, any>[]
+    ? // Is array of objects -- resolve each object in array
+      Array<{ [K in keyof T[number]]: Resolve<T[number][K]> }>
+    : // Array of non-objects (primitives) -- no action needed
+      T
+  : // All non-array types end up here:
+    //
+    // For primitives, this does nothing:
+    //
+    //    string -> string
+    //    number -> number
+    //    ...
+    //
+    // For intersections, this "flattens" them:
+    //
+    //    { a: string } & { b: number } -> { a: string, b: number }
+    //
+    // Built-in objects (Functions, Sets, etc) are "flattened" and lose
+    // information:
+    //
+    //    Set<any> -> { add: {}, clear: {}, delete: {} }
+    //
+    // Since this library only deals with JSON values, this behavior is OK.
+    //
+    // Unions are preserved for objects and primitives. However, arrays of
+    // object unions lose information:
+    //
+    //    { a: string } | { b: number } -> { a: string } | { b: number }
+    //    string | number -> string | number
+    //    Array<string | number> -> Array<string | number>
+    //    Array<{ a: string } | { b: number }> -> Array<{}>
+    //
+    // Since this library does not deal with unions, this behavior is OK.
+    { [K in keyof T]: Resolve<T[K]> };
+
+type MergeArrayIntoObject<T extends unknown[]> = T extends [infer R, ...infer U]
+  ? R & MergeArrayIntoObject<U>
+  : {};
+
+type Tokens = ["string", "number"];
+type Token = Tokens[number];
+
+type TokenToValue = {
+  string: string;
+  number: number;
+};
+
+// type ParseToken<T extends string> = T;
+type ParseToken<T extends string> = T extends Token
+  ? TokenToValue[T]
+  : CompileError<
+      [`Expected one of ${StringJoin<Tokens, ", ">} but got '${T}'`]
+    >;
+
+type FindValue<T extends string> = T extends `Array<{${infer R}}>`
+  ? _Parse<`{${R}}`>[]
+  : T extends `{${infer R}}`
+  ? _Parse<`{${R}}`>
+  : T extends `${infer Token}[] ${string}`
+  ? ParseToken<Token>[]
+  : T extends `${infer Token} ${string}`
+  ? ParseToken<Token>
+  : ParseToken<T>;
+
+type KeyValue<T extends string> = T extends `${infer K}:${infer Rest}`
+  ? { key: K; value: FindValue<TrimLeft<Rest>> }
+  : never;
+
+type ParseProperty<T extends string> = KeyValue<T> extends {
+  key: infer K;
+  value: infer V;
+}
+  ? K extends string
+    ? { [key in K]: V }
+    : {}
+  : {};
+
+type ParseProperties<T extends string[]> = {
+  [P in keyof T]: ParseProperty<Trim<T[P]>>;
+};
+
+type ExcludeFromTuple<T extends unknown[], Exclude> = T extends [
+  infer R,
+  ...infer Rest
+]
+  ? R extends Exclude
+    ? ExcludeFromTuple<Rest, Exclude>
+    : [R, ...ExcludeFromTuple<Rest, Exclude>]
+  : [];
+
+type RemoveEmptyStrings<T extends string[]> = ExcludeFromTuple<T, "">;
+
+type SplitIntoProperties<T extends string> =
+  T extends `${infer A}Array<{${infer O}}>${infer B}`
+    ? SplitIntoProperties<A> extends [...infer R, infer Last]
+      ? Last extends `${infer K}: `
+        ? [...R, `${K}:Array<{${O}}>`, ...SplitIntoProperties<B>]
+        : never
+      : never
+    : T extends `${infer A}{${infer O}}[]${infer B}`
+    ? SplitIntoProperties<A> extends [...infer R, infer Last]
+      ? Last extends `${infer K}: `
+        ? [...R, `${K}:Array<{${O}}>`, ...SplitIntoProperties<B>]
+        : never
+      : never
+    : T extends `${infer A}{${infer O}}${infer B}`
+    ? SplitIntoProperties<A> extends [...infer R, infer Last]
+      ? Last extends `${infer K}: `
+        ? [...R, `${K}:{${O}}`, ...SplitIntoProperties<B>]
+        : never
+      : never
+    : T extends `${infer A};${infer B}`
+    ? [A, ...SplitIntoProperties<B>]
+    : [T];
+
+type _Parse<T extends string> = T extends `{${infer R}}`
+  ? ParseProperties<RemoveEmptyStrings<SplitIntoProperties<R>>> extends [
+      ...infer U
+    ]
+    ? MergeArrayIntoObject<U>
+    : never
+  : CompileError<[`Expected {...}, got`, T]>;
+
+type Parse<T extends string> = Resolve<_Parse<Trim<T>>>;
+
+type Out = Parse<`{
+  a: string[] [email] = "test";
+  b: number [positive];
+  c: {
+    d: string;
+    e: {
+      hello: boolean;
+    }
+  }[];
+}`>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,6 @@ type TokenToValue = {
   number: number;
 };
 
-// type ParseToken<T extends string> = T;
 type ParseToken<T extends string> = T extends Token
   ? TokenToValue[T]
   : CompileError<

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,15 +144,4 @@ type _Parse<T extends string> = T extends `{${infer R}}`
     : never
   : CompileError<[`Expected {...}, got`, T]>;
 
-type Parse<T extends string> = Resolve<_Parse<Trim<T>>>;
-
-type Out = Parse<`{
-  a: string[] [email] = "test";
-  b: number [positive];
-  c: {
-    d: string;
-    e: {
-      hello: boolean;
-    }
-  }[];
-}`>;
+export type Parse<T extends string> = Resolve<_Parse<Trim<T>>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,11 @@
 import { StringJoin } from "./types/StringJoin";
 import { Trim, TrimLeft } from "./types/Trim";
 
-/**
- * We should never be able to create a value of this type legitimately.
- *
- * `ErrorMessageT` is our error message
- */
-interface CompileError<ErrorMessageT extends any[]> {
+interface CompileError<_Errors extends any[]> {
   /**
-   * There should never be a value of this type
+   * By adding this property, we prevent `{}` being assigned to it.
    */
-  readonly __compileError: never;
+  readonly __never: never;
 }
 
 type Key = string | number | symbol;

--- a/src/types/StringJoin.ts
+++ b/src/types/StringJoin.ts
@@ -1,0 +1,31 @@
+/**
+ * Joins a tuple of strings into a single string.
+ *
+ *    Input:
+ *      StringJoin<["a", "b", "c"], ", ">
+ *
+ *    Resolves to:
+ *      "a, b, c"
+ */
+export type StringJoin<
+  T extends string[],
+  Separator extends string = ""
+> = T extends [string, ...string[]]
+  ? `${T[0]}${HasTail<T> extends true
+      ? `${Separator}${StringJoin<Tail<T>, Separator>}`
+      : ""}`
+  : string[] extends T
+  ? // T is not more specific than 'string'
+    string
+  : "";
+
+type Tail<T extends string[]> = T extends [string, ...infer Rest]
+  ? Rest extends string[]
+    ? Rest
+    : never
+  : never;
+
+/** Resolves to true if there are >=2 strings in the tuple */
+type HasTail<T extends string[]> = T extends [string, string, ...string[]]
+  ? true
+  : false;

--- a/src/types/Trim.ts
+++ b/src/types/Trim.ts
@@ -1,0 +1,16 @@
+/** Removes spaces and newlines on the left of a string */
+export type TrimLeft<T extends string> = T extends ` ${infer R}`
+  ? TrimLeft<R>
+  : T extends `\n${infer R}`
+  ? TrimLeft<R>
+  : T;
+
+/** Removes spaces and newlines on the right of a string */
+export type TrimRight<T extends string> = T extends `${infer R} `
+  ? TrimRight<R>
+  : T extends `${infer R}\n`
+  ? TrimRight<R>
+  : T;
+
+/** Removes spaces and newlines on both sides of a string */
+export type Trim<T extends string> = TrimRight<TrimLeft<T>>;


### PR DESCRIPTION
# Schema templates

A very basic schema templates will look something like so:

```
{
  a: string;
  b: number;
}
```

We will allow some form of template "rules" like so:

```
{
  a: string <email>;
  b: number <int>;
}
```

Note: The syntax is not finalized. The rules will very likely look different.

We will also allow objects and arrays:

```
{
  a: string;
  b: number[] <int>;
  c: {
    d: string[];
  };
  e: Array<{ value: number }>;
}
```

Note: Both `Array<T>` and `T[]` will be allowed and treated as equivalent for now.

# `Parse` type

The `Parse` type takes a string literal and converts it to the type that it represents.

Usage of the `Parse` type looks like so:

```tsx
type A = Parse<`{
  a: string;
  b: number <int>;
}`>;
//=> { a: string, b: number }
```