### PR TITLE
Nested Object Properties

### DIFF
--- a/src/types/Equals.ts
+++ b/src/types/Equals.ts
@@ -1,0 +1,6 @@
+// See https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+export type Equals<X, Y> = (<T>() => T extends X ? 0 : 1) extends <
+  T
+>() => T extends Y ? 0 : 1
+  ? true
+  : false;

--- a/src/types/FilterString.ts
+++ b/src/types/FilterString.ts
@@ -1,8 +1,26 @@
+type ExcludeFromTuple<T extends string[], E> = T extends [
+  infer F extends string,
+  ...infer R extends string[]
+]
+  ? [F] extends [E]
+    ? ExcludeFromTuple<R, E>
+    : [F, ...ExcludeFromTuple<R, E>]
+  : [];
+
+type StringToTuple<T extends string> = T extends ""
+  ? []
+  : T extends `${infer C}${infer Rest}`
+  ? [C, ...StringToTuple<Rest>]
+  : never;
+
+type TupleToString<T extends string[]> = T extends [
+  infer R extends string,
+  ...infer Rest extends string[]
+]
+  ? `${R}${TupleToString<Rest>}`
+  : "";
+
 export type FilterString<
   T extends string,
   FilterBy extends string
-> = T extends `${infer R extends FilterBy}${infer After}`
-  ? `${R}${FilterString<After, FilterBy>}`
-  : T extends `${string}${infer R extends FilterBy}${infer After}`
-  ? `${R}${FilterString<After, FilterBy>}`
-  : "";
+> = TupleToString<ExcludeFromTuple<StringToTuple<T>, FilterBy>>;

--- a/src/types/FilterString.ts
+++ b/src/types/FilterString.ts
@@ -1,0 +1,8 @@
+export type FilterString<
+  T extends string,
+  FilterBy extends string
+> = T extends `${infer R extends FilterBy}${infer After}`
+  ? `${R}${FilterString<After, FilterBy>}`
+  : T extends `${string}${infer R extends FilterBy}${infer After}`
+  ? `${R}${FilterString<After, FilterBy>}`
+  : "";

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -41,6 +41,14 @@ it("parses arrays of objects as properties", () => [
   eq<Parse<`{ a: Array<{ b: number }> }`>, { a: Array<{ b: number }> }>(),
 ]);
 
+it("parses nested object properties", () => [
+  eq<Parse<`{ a: { b: {} } }`>, { a: { b: {} } }>(),
+  eq<
+    Parse<`{ a: { b: string; c: { d: number } } }`>,
+    { a: { b: string; c: { d: number } } }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -49,6 +49,13 @@ it("parses nested object properties", () => [
   >(),
 ]);
 
+it("parses multiple object properties", () => [
+  eq<
+    Parse<`{ a: { b: { c: number } }; d: { e: {}; f: {} } }`>,
+    { a: { b: { c: number } }; d: { e: {}; f: {} } }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -50,15 +50,30 @@ type JoinClosingBracesWithUnclosedObjectProperties<T extends string[]> =
   T extends [
     infer PrevProperty extends string,
     infer MaybeClosingBraces extends string,
-    ...infer Rest
+    ...infer Rest extends string[]
   ]
     ? Equals<
-        MaybeClosingBraces,
-        FilterString<MaybeClosingBraces, "}">
-      > extends true
-      ? [`${PrevProperty}${MaybeClosingBraces}`, ...Rest]
-      : T
+        StringLength<FilterString<PrevProperty, "{">>,
+        StringLength<FilterString<PrevProperty, "}">>
+      > extends false
+      ? JoinClosingBracesWithUnclosedObjectProperties<
+          [`${PrevProperty}${MaybeClosingBraces}`, ...Rest]
+        >
+      : [
+          PrevProperty,
+          ...JoinClosingBracesWithUnclosedObjectProperties<
+            [MaybeClosingBraces, ...Rest]
+          >
+        ]
     : T;
+
+type StringAsTuple<T extends string> = T extends ""
+  ? []
+  : T extends `${infer C}${infer Rest}`
+  ? [C, ...StringAsTuple<Rest>]
+  : never;
+
+type StringLength<T extends string> = StringAsTuple<T>["length"];
 
 type OnMatchedObjectPropertyDuringSplit<
   Before extends string,

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -44,7 +44,7 @@ import { StringWrapper, WrapString } from "./WrapString";
 // This type takes the closing braces ("}}") and joins them with the
 // previous property, resulting in:
 //
-//    ["a:{b:{c:{}}}", "d:string"]
+//    ["a:{b:{c:{};}}", "d:string"]
 //
 type JoinClosingBracesWithUnclosedObjectProperties<T extends string[]> =
   T extends [

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -57,7 +57,7 @@ type JoinClosingBracesWithUnclosedObjectProperties<T extends string[]> =
         StringLength<FilterString<PrevProperty, "}">>
       > extends false
       ? JoinClosingBracesWithUnclosedObjectProperties<
-          [`${PrevProperty}${MaybeClosingBraces}`, ...Rest]
+          [`${PrevProperty};${MaybeClosingBraces}`, ...Rest]
         >
       : [
           PrevProperty,

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -1,6 +1,64 @@
 import { CompileError } from "./CompileError";
+import { Equals } from "./Equals";
+import { FilterString } from "./FilterString";
 import { RemoveWhitespaceOnlyStringsFromTuple } from "./Whitespace";
 import { StringWrapper, WrapString } from "./WrapString";
+
+// When splitting properties, we cannot naively split by `;` because that would
+// improperly split object properties.
+//
+//    Before: "a:string;b:{c:string;d:number};e:number;"
+//
+//    After: ["a:string", "b:{c:string", "d:number}", "e:number"]
+//
+// So when splitting, we attempt to split the string with the following
+// pattern:
+//
+//    `${infer Before}{${infer InObject}}${infer After}`
+//
+// The literal `}` matching is greedy. It works fine for non-nested
+// object properties. The input here:
+//
+//    `a:{b:string};c:number`
+//
+// Becomes:
+//
+//    Before:   `a:`
+//    InObject: `b:string`
+//    After:    `c:number`
+//
+// Which we then piece back together like so (simplified):
+//
+//    [`${Before}{${InObject}}`, ...Split<After>]
+//
+// But nested object properties get split up in a different manner.
+//
+//    Before: "a:{b:{c:{}}};d:string"
+//
+//    After: ["a:", b:{c:{", "}}", "d:string"]
+//
+// And piecing this together as before, results in the following:
+//
+//    ["a:{b:{c:{}", "}}", "d:string"]
+//
+// This type takes the closing braces ("}}") and joins them with the
+// previous property, resulting in:
+//
+//    ["a:{b:{c:{}}}", "d:string"]
+//
+type JoinClosingBracesWithUnclosedObjectProperties<T extends string[]> =
+  T extends [
+    infer PrevProperty extends string,
+    infer MaybeClosingBraces extends string,
+    ...infer Rest
+  ]
+    ? Equals<
+        MaybeClosingBraces,
+        FilterString<MaybeClosingBraces, "}">
+      > extends true
+      ? [`${PrevProperty}${MaybeClosingBraces}`, ...Rest]
+      : T
+    : T;
 
 type OnMatchedObjectPropertyDuringSplit<
   Before extends string,
@@ -96,4 +154,6 @@ type _SplitIntoProperties<T extends string> =
 export type SplitIntoProperties<T extends string> =
   _SplitIntoProperties<T> extends CompileError<infer E>
     ? CompileError<E>
-    : RemoveWhitespaceOnlyStringsFromTuple<_SplitIntoProperties<T>>;
+    : JoinClosingBracesWithUnclosedObjectProperties<
+        RemoveWhitespaceOnlyStringsFromTuple<_SplitIntoProperties<T>>
+      >;

--- a/src/types/SplitIntoProperties.typecheck.ts
+++ b/src/types/SplitIntoProperties.typecheck.ts
@@ -43,4 +43,15 @@ it("does not split properties if ';' is not used by a separator", () => [
   eq<SplitIntoProperties<`a:string\nb:number`>, ["a:string\nb:number"]>(),
 ]);
 
+it("does not split nested object properties", () => [
+  eq<
+    SplitIntoProperties<`a:{b:{c:{}}};d:string;e:{}`>,
+    [`a:{b:{c:{}}}`, `d:string`, `e:{}`]
+  >(),
+  eq<
+    SplitIntoProperties<`a:{b:{c:{}}}[];d:string;e:{}`>,
+    [`a:Array<{b:{c:{}}}>`, `d:string`, `e:{}`]
+  >(),
+]);
+
 /** @todo test error cases */

--- a/src/types/SplitIntoProperties.typecheck.ts
+++ b/src/types/SplitIntoProperties.typecheck.ts
@@ -46,7 +46,11 @@ it("does not split properties if ';' is not used by a separator", () => [
 it("does not split nested object properties", () => [
   eq<
     SplitIntoProperties<`a:{b:{c:{}}};d:string;e:{}`>,
-    [`a:{b:{c:{}}}`, `d:string`, `e:{}`]
+    [`a:{b:{c:{};}}`, `d:string`, `e:{}`]
+  >(),
+  eq<
+    SplitIntoProperties<`a:{b:{c:{};d:{};e:{}}}`>,
+    [`a:{b:{c:{};d:{};e:{};}}`]
   >(),
   eq<
     SplitIntoProperties<`a:{b:{c:{}}}[];d:string;e:{}`>,

--- a/src/types/Test.ts
+++ b/src/types/Test.ts
@@ -1,13 +1,11 @@
-// See https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
-type Eq<X, Y> = (<T>() => T extends X ? 0 : 1) extends <T>() => T extends Y
-  ? 0
-  : 1
-  ? true
-  : false;
+import { Equals } from "./Equals";
 
 export declare function it(name: string, callback: () => true[]): void;
 
-export declare function eq<Type, Expect>(): Eq<Type, Expect>;
-export declare function not_eq<Type, Expect>(): Eq<Type, Expect> extends true
+export declare function eq<Type, Expect>(): Equals<Type, Expect>;
+export declare function not_eq<Type, Expect>(): Equals<
+  Type,
+  Expect
+> extends true
   ? false
   : true;


### PR DESCRIPTION
# Problem

`Parse` currently breaks when dealing with nested object properties:

```tsx
Parse<`{ a: { b: {} } }`>
// CompileError<["Expected key-value property, got '}'"]>
```

This happens because when `SplitIntoProperties` receives the content `a: { b: {} }` it attempts to find object properties like so:

```tsx
`${infer Before}{${infer InObject}}${infer After}`
```

This produces the following:

```
Before   = "a:"
InObject = "b: {"
After    = "}"
```

It then stitches these parts together like so (heavily simplified):

```tsx
[`${Before}{${InObject}}`, ...Split<After>]
```

which results in:

```tsx
["a:{b:{}", "}"]
```


# Generalizing the problem

Before we dive into the solution, let's take a more cases and generalize the problem.

This template:

```tsx
{a:{b:{c:number}};d:{e:{};f:{}}}
```

results in the following when run through `SplitIntoProperties`:

```tsx
["a:{b:{c:number}", "}", "d:{e:{}", "f:{}", "}"]
```

We can notice that there are two distinct groups:

```
Group A = ["a:{b:{c:number}", "}"]
Group B = ["d:{e:{}", "f:{}", "}"]
```

If the groups were joined, we would have the correct solution.

Here's another example:

```tsx
{a:{b:{c:{d:{}}}}}
```

which splits into

```tsx
["a:{b:{c:{d:{}", "}}}"]
```

The first example demonstrates that the trailing `}` is not always right after the `{` that it closes. There can be other object properties between (in this case `f:{}`).

The latter example demonstrates that we don't always end up with a single trailing `}`, we can have multiple in a single part (such as `}}}`).


# Solution

The fact that a single object property can be comprised of three or more strings means that we may need to merge strings multiple times. We need to do something along the lines of:

```tsx
while (hasNotFoundClosingBrace) {
  mergeNext()
}
```

But how do we know if we have found the closing brace? We can check whether the merged string is "balanced". We can define balanced as:

> Is the number of `{` in the string equal to the number of `}` in the string?

We can check whether a string is balanced like so:

```tsx
Equals<
  StringLength<FilterString<S, "{">>,
  StringLength<FilterString<S, "}">>
>
```

Let's work this out by hand. The starting state looks like so:

```tsx
A = ["a:{b:{c:number}", "}", "d:{e:{}", "f:{}", "}"]
Index = 0
```

The algorithm works like so:

 1. if `A[Index]` is unbalanced, merge it with `A[Index + 1]`
 2. if `A[Index]` is balanced, set `Index` to `Index + 1`

On the first iteration, `A[0]` is unbalanced so we join:

```tsx
A = ["a:{b:{c:number}}", "d:{e:{}", "f:{}", "}"]
Index = 0
```

`A[0]` is now balanced, so we move to `A[1]`. `A[1]` is unbalanced so we join:

```tsx
A = ["a:{b:{c:number}}", "d:{e:{}f:{}", "}"]
Index = 1
```

`A[1]` is still unbalanced, so we keep joining:

```tsx
A = ["a:{b:{c:number}}", "d:{e:{}f:{}}"]
Index = 1
```

`A[1]` is now balanced and we are at the end of the array so we stop. This produced the correct result.

## What if there is an error in the template?

If the template has error e.g. too many opening braces `a:{b:{{{}}`? Well, then we just encounter an error later when parsing the string:

```tsx
Parse<`{ a: { b: {{} } }`>
// {
//   a: {
//     b: CompileError<[
//       "Failed to parse value of property 'b'",
//       "Expected key-value property, got '{'",
//     ]>;
//   };
// }
```

