### PR TITLE
Support Arrays of Primitives

### DIFF
--- a/src/types/Parse.ts
+++ b/src/types/Parse.ts
@@ -21,15 +21,27 @@ type ParseToken<T extends string> = T extends Token
   ? TokenToValue[T]
   : Err<[`Expected one of [${StringJoin<Tokens, ", ">}] but got '${T}'`]>;
 
-type FindValue<T extends string> = T extends `Array<{${infer R}}>`
-  ? _Parse<`{${R}}`>[]
-  : T extends `{${infer R}}`
-  ? _Parse<`{${R}}`>
-  : T extends `${infer Token}[] ${string}`
-  ? ParseToken<Token>[]
-  : T extends `${infer Token} ${string}`
-  ? ParseToken<Token>
-  : ParseToken<T>;
+type FindValue<T extends string> =
+  // Array of objects
+  T extends `Array<{${infer R}}>`
+    ? _Parse<`{${R}}`>[]
+    : T extends `{${infer R}}`
+    ? _Parse<`{${R}}`>
+    : //
+    // Array of primitives (without rules)
+    T extends `${infer Token}[]`
+    ? ParseToken<Token>[]
+    : //
+    // Array of primitives (with rules)
+    T extends `${infer Token}[]<${string}>`
+    ? ParseToken<Token>[]
+    : //
+    // Primitive with rules
+    T extends `${infer Token}<${string}>`
+    ? ParseToken<Token>
+    : //
+      // When none of the above matched, we expect to find just a primitive
+      ParseToken<T>;
 
 type KeyValue<T extends string> = T extends `${infer K}:${infer Rest}`
   ? {

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -31,6 +31,29 @@ it("requires a ';' beween properties", () => [
   not_eq<Parse<`{ a: string, b: number }`>, { a: string; b: number }>(),
 ]);
 
+it("parses arrays of primitives", () => [
+  eq<Parse<`{ a: string[]; }`>, { a: string[] }>(),
+  eq<
+    Parse<`{ a: string[]; b: { c: number[] } }`>,
+    { a: string[]; b: { c: number[] } }
+  >(),
+]);
+
+it("ignores rules in '<>' for primitives", () => [
+  eq<Parse<`{ a: string[] <abcd> }`>, { a: string[] }>(),
+  eq<
+    Parse<`{ a: string[] abcd }`>,
+    {
+      a: CompileError<
+        [
+          "Failed to parse value of property 'a'",
+          "Expected one of [string, number] but got 'string[]abcd'"
+        ]
+      >;
+    }
+  >(),
+]);
+
 it("parses objects as properties", () => [eq<Parse<`{ a: {} }`>, { a: {} }>()]);
 
 it("parses arrays of objects as properties", () => [


### PR DESCRIPTION
Arrays of primitives can now be specified like so:

```tsx
Parse<`{ a: string[]; b: number[] }`>
```

Rules for primitives may be specified like so:

```tsx
Parse<`{ a: string[] <rules>; b: number[] <rules> }`>
```

All content in `<>` is ignored by `Parse`, but `compileStylesheet` will soon be able to read them.