### PR TITLE
Parse Rules

### DIFF
--- a/src/ast/astFromString.spec.ts
+++ b/src/ast/astFromString.spec.ts
@@ -17,7 +17,7 @@ describe("astFromString", () => {
         {
           type: "property",
           key: "a",
-          value: { type: "primitive", valueType: "string" },
+          value: { type: "primitive", valueType: "string", rules: [] },
         },
       ],
     };
@@ -33,12 +33,12 @@ describe("astFromString", () => {
         {
           type: "property",
           key: "a",
-          value: { type: "primitive", valueType: "string" },
+          value: { type: "primitive", valueType: "string", rules: [] },
         },
         {
           type: "property",
           key: "b",
-          value: { type: "primitive", valueType: "number" },
+          value: { type: "primitive", valueType: "number", rules: [] },
         },
       ],
     };
@@ -67,7 +67,7 @@ describe("astFromString", () => {
               {
                 type: "property",
                 key: "b",
-                value: { type: "primitive", valueType: "string" },
+                value: { type: "primitive", valueType: "string", rules: [] },
               },
             ],
           },
@@ -98,7 +98,11 @@ describe("astFromString", () => {
                     {
                       type: "property",
                       key: "c",
-                      value: { type: "primitive", valueType: "string" },
+                      value: {
+                        type: "primitive",
+                        valueType: "string",
+                        rules: [],
+                      },
                     },
                   ],
                 },
@@ -122,7 +126,7 @@ describe("astFromString", () => {
           key: "a",
           value: {
             type: "array",
-            value: { type: "primitive", valueType: "string" },
+            value: { type: "primitive", valueType: "string", rules: [] },
           },
         },
       ],
@@ -147,7 +151,7 @@ describe("astFromString", () => {
                 {
                   type: "property",
                   key: "b",
-                  value: { type: "primitive", valueType: "string" },
+                  value: { type: "primitive", valueType: "string", rules: [] },
                 },
               ],
             },

--- a/src/ast/parse/property.spec.ts
+++ b/src/ast/parse/property.spec.ts
@@ -1,0 +1,50 @@
+import { ObjectNode, PrimitiveNode } from "../../types/Ast";
+import { Rule } from "../../types/Rule";
+import { ParserState } from "../state/ParserState";
+import { parseProperty } from "./property";
+
+describe("parseProperty", () => {
+  it("parses the key and value of a primitive property", () => {
+    const state = new ParserState(`a: string`);
+
+    const parsed = parseProperty(state);
+    const value = parsed.value as PrimitiveNode;
+
+    expect(parsed.key).toEqual("a");
+    expect(value.type).toEqual("primitive");
+    expect(value.valueType).toEqual("string");
+  });
+
+  it("parses rules for a primitive property", () => {
+    const state = new ParserState(`a: string <email>`);
+    const expectedRules: Rule[] = [{ type: "email" }];
+
+    const value = parseProperty(state).value as PrimitiveNode;
+
+    expect(value.rules).toEqual(expectedRules);
+  });
+
+  it("parses a list of rules for a primitive property", () => {
+    const state = new ParserState(`a: number <int, positive>`);
+
+    const value = parseProperty(state).value as PrimitiveNode;
+
+    expect(value.rules.length).toEqual(2);
+  });
+
+  it("parses an object property", () => {
+    const state = new ParserState(`a: {}`);
+
+    const value = parseProperty(state).value;
+
+    expect(value.type).toEqual("object");
+  });
+
+  it("parses the properties of an object property", () => {
+    const state = new ParserState(`a: { b: number; c: string }`);
+
+    const value = parseProperty(state).value as ObjectNode;
+
+    expect(value.properties.length).toEqual(2);
+  });
+});

--- a/src/ast/parse/property.spec.ts
+++ b/src/ast/parse/property.spec.ts
@@ -47,22 +47,26 @@ describe("parseProperty", () => {
     expect(value.properties.length).toEqual(2);
   });
 
-  it("parses an array of primitives or objects", () => {
-    const templates = [
-      { template: `a: string[]`, type: "primitive" },
-      { template: `a: {}[]`, type: "object" },
-    ];
+  it("parses an array of primitives", () => {
+    const state = new ParserState(`strArr: string[]`);
 
-    for (const { template, type } of templates) {
-      const state = new ParserState(template);
+    const property = parseProperty(state);
+    const value = property.value as ArrayNode;
 
-      const property = parseProperty(state);
-      const value = property.value as ArrayNode;
+    expect(property.key).toEqual("strArr");
+    expect(value.type).toEqual("array");
+    expect(value.value.type).toEqual("primitive");
+  });
 
-      expect(property.key).toEqual("a");
-      expect(value.type).toEqual("array");
-      expect(value.value.type).toEqual(type);
-    }
+  it("parses an array of objects", () => {
+    const state = new ParserState(`objArr: {}[]`);
+
+    const property = parseProperty(state);
+    const value = property.value as ArrayNode;
+
+    expect(property.key).toEqual("objArr");
+    expect(value.type).toEqual("array");
+    expect(value.value.type).toEqual("object");
   });
 
   it("parses the rules for an array of primitives", () => {

--- a/src/ast/parse/property.spec.ts
+++ b/src/ast/parse/property.spec.ts
@@ -1,4 +1,4 @@
-import { ObjectNode, PrimitiveNode } from "../../types/Ast";
+import { ArrayNode, ObjectNode, PrimitiveNode } from "../../types/Ast";
 import { ParserState } from "../state/ParserState";
 import { parseProperty } from "./property";
 
@@ -45,5 +45,32 @@ describe("parseProperty", () => {
     const value = parseProperty(state).value as ObjectNode;
 
     expect(value.properties.length).toEqual(2);
+  });
+
+  it("parses an array of primitives or objects", () => {
+    const templates = [
+      { template: `a: string[]`, type: "primitive" },
+      { template: `a: {}[]`, type: "object" },
+    ];
+
+    for (const { template, type } of templates) {
+      const state = new ParserState(template);
+
+      const property = parseProperty(state);
+      const value = property.value as ArrayNode;
+
+      expect(property.key).toEqual("a");
+      expect(value.type).toEqual("array");
+      expect(value.value.type).toEqual(type);
+    }
+  });
+
+  it("parses the rules for an array of primitives", () => {
+    const state = new ParserState(`emails: string[] <email>`);
+
+    const value = parseProperty(state).value as ArrayNode;
+    const primitive = value.value as PrimitiveNode;
+
+    expect(primitive.rules.length).toEqual(1);
   });
 });

--- a/src/ast/parse/property.spec.ts
+++ b/src/ast/parse/property.spec.ts
@@ -1,5 +1,4 @@
 import { ObjectNode, PrimitiveNode } from "../../types/Ast";
-import { Rule } from "../../types/Rule";
 import { ParserState } from "../state/ParserState";
 import { parseProperty } from "./property";
 
@@ -15,13 +14,13 @@ describe("parseProperty", () => {
     expect(value.valueType).toEqual("string");
   });
 
-  it("parses rules for a primitive property", () => {
+  it("parses a single rule for a primitive property", () => {
     const state = new ParserState(`a: string <email>`);
-    const expectedRules: Rule[] = [{ type: "email" }];
 
     const value = parseProperty(state).value as PrimitiveNode;
 
-    expect(value.rules).toEqual(expectedRules);
+    expect(value.rules.length).toEqual(1);
+    expect(value.rules[0].type).toEqual("email");
   });
 
   it("parses a list of rules for a primitive property", () => {

--- a/src/ast/parse/property.ts
+++ b/src/ast/parse/property.ts
@@ -32,7 +32,7 @@ function parseIsArray(state: ParserState) {
   return isArray;
 }
 
-function parseProperty(state: ParserState): PropertyNode {
+export function parseProperty(state: ParserState): PropertyNode {
   const key = parseKey(state);
 
   state.nextToken();

--- a/src/ast/parse/property.ts
+++ b/src/ast/parse/property.ts
@@ -13,6 +13,24 @@ function parseKey(state: ParserState): string {
   return state.token();
 }
 
+function parseIsArray(state: ParserState) {
+  let isArray: boolean;
+
+  if (state.atDelimeter("[")) {
+    state.nextToken();
+    if (!state.atDelimeter("]")) {
+      throw new Error(`Expected ']'`);
+    }
+    state.nextToken();
+
+    isArray = true;
+  } else {
+    isArray = false;
+  }
+
+  return isArray;
+}
+
 function parseProperty(state: ParserState): PropertyNode {
   const key = parseKey(state);
 
@@ -25,25 +43,15 @@ function parseProperty(state: ParserState): PropertyNode {
   state.nextToken();
 
   const value = parseValue(state);
-
-  let property: PropertyNode;
-
-  if (state.atDelimeter("[")) {
-    state.nextToken();
-    if (!state.atDelimeter("]")) {
-      throw new Error(`Expected ']'`);
-    }
-    property = {
-      type: "property",
-      key,
-      value: { type: "array", value },
-    };
-    state.nextToken();
-  } else {
-    property = { type: "property", key, value };
-  }
+  const isArray = parseIsArray(state);
 
   /** @todo check for rules */
+
+  const property: PropertyNode = { type: "property", key, value };
+
+  if (isArray) {
+    property.value = { type: "array", value: property.value };
+  }
 
   return property;
 }

--- a/src/ast/parse/property.ts
+++ b/src/ast/parse/property.ts
@@ -1,6 +1,7 @@
 import { PropertyNode } from "../../types/Ast";
 import { ParserState } from "../state/ParserState";
 import { TokenType } from "../token";
+import { parseRules } from "./rules";
 import { parseValue } from "./value";
 
 function parseKey(state: ParserState): string {
@@ -45,7 +46,9 @@ function parseProperty(state: ParserState): PropertyNode {
   const value = parseValue(state);
   const isArray = parseIsArray(state);
 
-  /** @todo check for rules */
+  if (value.type === "primitive") {
+    value.rules = parseRules(state, value.valueType);
+  }
 
   const property: PropertyNode = { type: "property", key, value };
 

--- a/src/ast/parse/resolveRule.ts
+++ b/src/ast/parse/resolveRule.ts
@@ -1,8 +1,8 @@
 import { PrimitiveType } from "../../types/Ast";
-import { Rule } from "../../types/rule";
+import { Rule, RuleType } from "../../types/rule";
 
 interface RuleTest {
-  rule: Rule["type"];
+  rule: RuleType;
   primitiveType: PrimitiveType;
   requiresNumericArgument: boolean;
   toRule: (arg: number | null) => Rule;

--- a/src/ast/parse/resolveRule.ts
+++ b/src/ast/parse/resolveRule.ts
@@ -1,5 +1,5 @@
 import { PrimitiveType } from "../../types/Ast";
-import { Rule, RuleType } from "../../types/rule";
+import { Rule, RuleType } from "../../types/Rule";
 
 interface RuleTest {
   rule: RuleType;

--- a/src/ast/parse/resolveRule.ts
+++ b/src/ast/parse/resolveRule.ts
@@ -22,10 +22,10 @@ const ruleTests: RuleTest[] = [
     toRule: () => ({ type: "positive" }),
   },
   {
-    rule: "integer",
+    rule: "int",
     primitiveType: "number",
     requiresNumericArgument: false,
-    toRule: () => ({ type: "integer" }),
+    toRule: () => ({ type: "int" }),
   },
   {
     rule: "min",

--- a/src/ast/parse/resolveRule.ts
+++ b/src/ast/parse/resolveRule.ts
@@ -1,14 +1,9 @@
-import { PrimitiveNode } from "../../types/Ast";
+import { PrimitiveType } from "../../types/Ast";
 import { Rule } from "../../types/rule";
-
-enum PrimitiveType {
-  String = "string",
-  Number = "number",
-}
 
 interface RuleTest {
   rule: Rule["type"];
-  valueType: PrimitiveType;
+  primitiveType: PrimitiveType;
   requiresNumericArgument: boolean;
   toRule: (arg: number | null) => Rule;
 }
@@ -16,31 +11,31 @@ interface RuleTest {
 const ruleTests: RuleTest[] = [
   {
     rule: "email",
-    valueType: PrimitiveType.String,
+    primitiveType: "string",
     requiresNumericArgument: false,
     toRule: () => ({ type: "email" }),
   },
   {
     rule: "positive",
-    valueType: PrimitiveType.Number,
+    primitiveType: "number",
     requiresNumericArgument: false,
     toRule: () => ({ type: "positive" }),
   },
   {
     rule: "integer",
-    valueType: PrimitiveType.Number,
+    primitiveType: "number",
     requiresNumericArgument: false,
     toRule: () => ({ type: "integer" }),
   },
   {
     rule: "min",
-    valueType: PrimitiveType.Number,
+    primitiveType: "number",
     requiresNumericArgument: true,
     toRule: (arg) => ({ type: "min", value: arg! }),
   },
   {
     rule: "max",
-    valueType: PrimitiveType.Number,
+    primitiveType: "number",
     requiresNumericArgument: true,
     toRule: (arg) => ({ type: "max", value: arg! }),
   },
@@ -52,11 +47,10 @@ const ruleTestsByName = ruleTests.reduce((obj, ruleTest) => {
 }, {} as Partial<Record<string, RuleTest>>);
 
 export function resolveRule(
-  primitiveNode: PrimitiveNode,
+  primitiveType: PrimitiveType,
   rule: string,
   arg: number | null
 ) {
-  const { valueType } = primitiveNode;
   const hasArg = arg !== null;
 
   const ruleTest = ruleTestsByName[rule];
@@ -65,10 +59,10 @@ export function resolveRule(
     throw new Error(`Unknown rule '${rule}'`);
   }
 
-  if (ruleTest.valueType !== valueType) {
+  if (ruleTest.primitiveType !== primitiveType) {
     throw new Error(
-      `Rule '${rule}' expects a ${ruleTest.valueType}, ` +
-        `you provided a ${valueType} value`
+      `Rule '${rule}' expects a ${ruleTest.primitiveType}, ` +
+        `you provided a ${primitiveType} value`
     );
   }
 

--- a/src/ast/parse/resolveRule.ts
+++ b/src/ast/parse/resolveRule.ts
@@ -1,0 +1,84 @@
+import { PrimitiveNode } from "../../types/Ast";
+import { Rule } from "../../types/rule";
+
+enum PrimitiveType {
+  String = "string",
+  Number = "number",
+}
+
+interface RuleTest {
+  rule: Rule["type"];
+  valueType: PrimitiveType;
+  requiresNumericArgument: boolean;
+  toRule: (arg: number | null) => Rule;
+}
+
+const ruleTests: RuleTest[] = [
+  {
+    rule: "email",
+    valueType: PrimitiveType.String,
+    requiresNumericArgument: false,
+    toRule: () => ({ type: "email" }),
+  },
+  {
+    rule: "positive",
+    valueType: PrimitiveType.Number,
+    requiresNumericArgument: false,
+    toRule: () => ({ type: "positive" }),
+  },
+  {
+    rule: "integer",
+    valueType: PrimitiveType.Number,
+    requiresNumericArgument: false,
+    toRule: () => ({ type: "integer" }),
+  },
+  {
+    rule: "min",
+    valueType: PrimitiveType.Number,
+    requiresNumericArgument: true,
+    toRule: (arg) => ({ type: "min", value: arg! }),
+  },
+  {
+    rule: "max",
+    valueType: PrimitiveType.Number,
+    requiresNumericArgument: true,
+    toRule: (arg) => ({ type: "max", value: arg! }),
+  },
+];
+
+const ruleTestsByName = ruleTests.reduce((obj, ruleTest) => {
+  obj[ruleTest.rule] = ruleTest;
+  return obj;
+}, {} as Partial<Record<string, RuleTest>>);
+
+export function resolveRule(
+  primitiveNode: PrimitiveNode,
+  rule: string,
+  arg: number | null
+) {
+  const { valueType } = primitiveNode;
+  const hasArg = arg !== null;
+
+  const ruleTest = ruleTestsByName[rule];
+
+  if (!ruleTest) {
+    throw new Error(`Unknown rule '${rule}'`);
+  }
+
+  if (ruleTest.valueType !== valueType) {
+    throw new Error(
+      `Rule '${rule}' expects a ${ruleTest.valueType}, ` +
+        `you provided a ${valueType} value`
+    );
+  }
+
+  if (ruleTest.requiresNumericArgument && !hasArg) {
+    throw new Error(`Rule '${rule}' expects a single numeric argument.`);
+  }
+
+  if (!ruleTest.requiresNumericArgument && hasArg) {
+    throw new Error(`Rule '${rule}' expects no arguments.`);
+  }
+
+  return ruleTest.toRule(arg);
+}

--- a/src/ast/parse/rules.spec.ts
+++ b/src/ast/parse/rules.spec.ts
@@ -1,49 +1,42 @@
-import { Rule } from "../../types/Rule";
+import { NumberMinRule } from "../../types/Rule";
 import { ParserState } from "../state/ParserState";
 import { parseRule, parseRules } from "./rules";
 
 describe("parseRule", () => {
   it("parses a single rule with no arguments", () => {
     const state = new ParserState(`positive`);
-    const expectedRule: Rule = { type: "positive" };
 
     const rule = parseRule(state, "number");
 
-    expect(rule).toEqual(expectedRule);
+    expect(rule.type).toEqual("positive");
   });
 
   it("parses a single rule with an arguments", () => {
     const state = new ParserState(`min(5)`);
-    const expectedRule: Rule = { type: "min", value: 5 };
 
-    const rule = parseRule(state, "number");
+    const rule = parseRule(state, "number") as NumberMinRule;
 
-    expect(rule).toEqual(expectedRule);
+    expect(rule.type).toEqual("min");
+    expect(rule.value).toEqual(5);
   });
 
   it("moves to the next token after the rule", () => {
-    // With parens
     {
+      // With parens
       const state = new ParserState(`min(1), max(2)`);
-      const expectedRule: Rule = { type: "min", value: 1 };
 
-      const rule = parseRule(state, "number");
-      const nextToken = state.token();
+      parseRule(state, "number");
 
-      expect(rule).toEqual(expectedRule);
-      expect(nextToken).toEqual(",");
+      expect(state.token()).toEqual(",");
     }
 
-    // Without parens
     {
+      // Without parens
       const state = new ParserState(`int, positive`);
-      const expectedRule: Rule = { type: "int" };
 
-      const rule = parseRule(state, "number");
-      const nextToken = state.token();
+      parseRule(state, "number");
 
-      expect(rule).toEqual(expectedRule);
-      expect(nextToken).toEqual(",");
+      expect(state.token()).toEqual(",");
     }
   });
 
@@ -93,20 +86,18 @@ describe("parseRule", () => {
 describe("parseRules", () => {
   it("parses a single rule", () => {
     const state = new ParserState(`<positive>`);
-    const expectedRules: Rule[] = [{ type: "positive" }];
 
     const rules = parseRules(state, "number");
 
-    expect(rules).toEqual(expectedRules);
+    expect(rules.length).toEqual(1);
   });
 
   it("parses multiple rules", () => {
-    const state = new ParserState(`<positive, int>`);
-    const expectedRules: Rule[] = [{ type: "positive" }, { type: "int" }];
+    const state = new ParserState(`<max(10), int, min(5)>`);
 
     const rules = parseRules(state, "number");
 
-    expect(rules).toEqual(expectedRules);
+    expect(rules.length).toEqual(3);
   });
 
   it("throws if no closing '>' is provided", () => {

--- a/src/ast/parse/rules.spec.ts
+++ b/src/ast/parse/rules.spec.ts
@@ -1,0 +1,67 @@
+import { Rule } from "../../types/Rule";
+import { ParserState } from "../state/ParserState";
+import { parseRule } from "./rules";
+
+describe("parseRule", () => {
+  it("parses a single rule with no arguments", () => {
+    const state = new ParserState(`positive`);
+    const expectedRule: Rule = { type: "positive" };
+
+    const rule = parseRule(state, "number");
+
+    expect(rule).toEqual(expectedRule);
+  });
+
+  it("parses a single rule with an arguments", () => {
+    const state = new ParserState(`min(5)`);
+    const expectedRule: Rule = { type: "min", value: 5 };
+
+    const rule = parseRule(state, "number");
+
+    expect(rule).toEqual(expectedRule);
+  });
+
+  it("moves to the next rule to parse", () => {
+    const state = new ParserState(`min(1), max(2)`);
+    const expectedRule: Rule = { type: "min", value: 1 };
+
+    const rule = parseRule(state, "number");
+    const nextToken = state.token();
+
+    expect(rule).toEqual(expectedRule);
+    expect(nextToken).toEqual("max");
+  });
+
+  it("allows for trailing ',' at the end of the list of rules", () => {
+    const states = [
+      new ParserState(`min(1),\n>`),
+      new ParserState(`min(1),>`),
+      new ParserState(`min(1)>`),
+    ];
+    const expectedRule: Rule = { type: "min", value: 1 };
+
+    for (const state of states) {
+      const rule = parseRule(state, "number");
+      const nextToken = state.token();
+
+      expect(rule).toEqual(expectedRule);
+      expect(nextToken).toEqual(">");
+    }
+  });
+
+  it("throws an error if multiple arguments are provided", () => {
+    const state = new ParserState(`min(1, 2)`);
+
+    const parse = () => parseRule(state, "number");
+
+    expect(parse).toThrow("Unexpected token ',', expected ')'");
+  });
+
+  it("throws an error if it does not encounter a rule name", () => {
+    const state = new ParserState(`,min(1, 2)`);
+
+    const parse = () => parseRule(state, "number");
+
+    expect(parse).toThrow("Expected rule name, got ','");
+  });
+});

--- a/src/ast/parse/rules.spec.ts
+++ b/src/ast/parse/rules.spec.ts
@@ -22,14 +22,29 @@ describe("parseRule", () => {
   });
 
   it("moves to the next token after the rule", () => {
-    const state = new ParserState(`min(1), max(2)`);
-    const expectedRule: Rule = { type: "min", value: 1 };
+    // With parens
+    {
+      const state = new ParserState(`min(1), max(2)`);
+      const expectedRule: Rule = { type: "min", value: 1 };
 
-    const rule = parseRule(state, "number");
-    const nextToken = state.token();
+      const rule = parseRule(state, "number");
+      const nextToken = state.token();
 
-    expect(rule).toEqual(expectedRule);
-    expect(nextToken).toEqual(",");
+      expect(rule).toEqual(expectedRule);
+      expect(nextToken).toEqual(",");
+    }
+
+    // Without parens
+    {
+      const state = new ParserState(`int, positive`);
+      const expectedRule: Rule = { type: "int" };
+
+      const rule = parseRule(state, "number");
+      const nextToken = state.token();
+
+      expect(rule).toEqual(expectedRule);
+      expect(nextToken).toEqual(",");
+    }
   });
 
   it("throws an error if an argument is provided ", () => {

--- a/src/ast/parse/rules.spec.ts
+++ b/src/ast/parse/rules.spec.ts
@@ -49,6 +49,14 @@ describe("parseRule", () => {
     }
   });
 
+  it("throws an error if an argument is provided ", () => {
+    const state = new ParserState(`int(2)`);
+
+    const parse = () => parseRule(state, "number");
+
+    expect(parse).toThrow("Rule 'int' expects no arguments.");
+  });
+
   it("throws an error if multiple arguments are provided", () => {
     const state = new ParserState(`min(1, 2)`);
 
@@ -63,5 +71,23 @@ describe("parseRule", () => {
     const parse = () => parseRule(state, "number");
 
     expect(parse).toThrow("Expected rule name, got ','");
+  });
+
+  it("throws an error if an unknown rule name is provided", () => {
+    const state = new ParserState(`emial`);
+
+    const parse = () => parseRule(state, "string");
+
+    expect(parse).toThrow("Unknown rule 'emial'");
+  });
+
+  it("throws an error if the primitive type does not match", () => {
+    const state = new ParserState(`email`);
+
+    const parse = () => parseRule(state, "number");
+
+    expect(parse).toThrow(
+      "Rule 'email' expects a string, you provided a number value"
+    );
   });
 });

--- a/src/ast/parse/rules.ts
+++ b/src/ast/parse/rules.ts
@@ -1,0 +1,79 @@
+import { PrimitiveNode } from "../../types/Ast";
+import { Rule } from "../../types/Rule";
+import { ParserState } from "../state/ParserState";
+import { TokenType } from "../token";
+import { resolveRule } from "./resolveRule";
+
+function parseRuleArgument(state: ParserState): number | null {
+  if (!state.atDelimeter("(")) {
+    return null;
+  }
+  state.nextToken();
+
+  if (state.tokenType() !== TokenType.Number) {
+    throw new Error(`Expected numeric argument, got '${state.token()}'`);
+  }
+
+  const value = Number(state.token());
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`Expected finite number, got '${value}'`);
+  }
+
+  if (!state.atDelimeter(")")) {
+    throw new Error(`Unexpected token '${state.token()}'`);
+  }
+
+  return value;
+}
+
+function parseRule(state: ParserState, primitiveNode: PrimitiveNode): Rule {
+  // Rules are comprised of a symbol, optionally followed by a single
+  // argument within parenthesis (like a function call):
+  //
+  //    - int
+  //    - min(1)
+  //
+  // The rules are contained within '<>' and separated by a comma ','.
+  //
+  //    - <int>
+  //    - <min(1)>
+  //    - <int, min(0), max(10)>
+  //
+  // After parsing a rule, skip over the comma ',' if present.
+
+  if (state.tokenType() !== TokenType.Symbol) {
+    throw new Error(`Unexpected token '${state.token()}'`);
+  }
+
+  const ruleName = state.token();
+  const arg = parseRuleArgument(state);
+
+  const rule = resolveRule(primitiveNode, ruleName, arg);
+
+  if (state.atDelimeter(",")) {
+    state.nextToken();
+  }
+
+  return rule;
+}
+
+export function parseRules(
+  state: ParserState,
+  primitiveNode: PrimitiveNode
+): Rule[] {
+  const rules: Rule[] = [];
+
+  if (!state.atDelimeter("<")) {
+    return rules;
+  }
+  state.nextToken();
+
+  while (!state.atDelimeter(">")) {
+    const rule = parseRule(state, primitiveNode);
+    rules.push(rule);
+  }
+  state.nextToken();
+
+  return rules;
+}

--- a/src/ast/parse/rules.ts
+++ b/src/ast/parse/rules.ts
@@ -58,10 +58,6 @@ export function parseRule(
 
   const rule = resolveRule(primitiveType, ruleName, arg);
 
-  if (state.atDelimeter(",")) {
-    state.nextToken();
-  }
-
   return rule;
 }
 
@@ -78,6 +74,13 @@ export function parseRules(
 
   while (!state.atDelimeter(">")) {
     const rule = parseRule(state, primitiveType);
+
+    if (state.atDelimeter(",")) {
+      state.nextToken();
+    } else if (!state.atDelimeter(">")) {
+      throw new Error(`Expected ',' or '>', got '${state.token()}'`);
+    }
+
     rules.push(rule);
   }
   state.nextToken();

--- a/src/ast/parse/value.spec.ts
+++ b/src/ast/parse/value.spec.ts
@@ -1,8 +1,14 @@
-import { ValueNode } from "../../types/Ast";
+import { PrimitiveNode, PrimitiveType, ValueNode } from "../../types/Ast";
 import { ParserState } from "../state/ParserState";
 import { parseValue } from "./value";
 import { parseObject } from "./object";
 import { TokenType } from "../token";
+
+const primitiveNode = (valueType: PrimitiveType): PrimitiveNode => ({
+  type: "primitive",
+  valueType,
+  rules: [], // Rules are not parsed by 'parseValue'
+});
 
 jest.mock("./object", () => {
   const originalModule = jest.requireActual("./object");
@@ -16,7 +22,7 @@ jest.mock("./object", () => {
 describe("parseValue", () => {
   it("parses a primitive value", () => {
     const state = new ParserState(`string;`);
-    const expectedValue: ValueNode = { type: "primitive", valueType: "string" };
+    const expectedValue: ValueNode = primitiveNode("string");
 
     const value = parseValue(state);
     const nextToken = state.token();
@@ -27,7 +33,7 @@ describe("parseValue", () => {
 
   it("does not consider arrays", () => {
     const state = new ParserState(`number[];`);
-    const expectedValue: ValueNode = { type: "primitive", valueType: "number" };
+    const expectedValue: ValueNode = primitiveNode("number");
 
     const value = parseValue(state);
     const nextToken = state.token();

--- a/src/ast/parse/value.ts
+++ b/src/ast/parse/value.ts
@@ -23,7 +23,11 @@ export function parseValue(state: ParserState): ValueNode {
       if (!isPrimitiveSymbol(token)) {
         throw new Error(`Unknown symbol '${token}'`);
       }
-      value = { type: "primitive", valueType: token };
+      value = {
+        type: "primitive",
+        valueType: token,
+        rules: [], // The rules are added later in 'parseProperty'
+      };
       state.nextToken();
       break;
     }
@@ -36,6 +40,8 @@ export function parseValue(state: ParserState): ValueNode {
     }
     case TokenType.None:
       throw new Error(`Expected end of template`);
+    case TokenType.Number:
+      throw new Error(`Unexpected token type '${tokenType}'`);
     default:
       enforceExhaustive(tokenType, `Unexpected token type`);
   }

--- a/src/ast/state/ParserState.ts
+++ b/src/ast/state/ParserState.ts
@@ -1,6 +1,18 @@
 import { TokenType } from "../token";
 
-const delimeters = new Set([":", ";", "{", "}", "[", "]", "<", ">"]);
+const delimeters = new Set([
+  ":",
+  ";",
+  "{",
+  "}",
+  "[",
+  "]",
+  "<",
+  ">",
+  "(",
+  ")",
+  ",",
+]);
 const whitespace = new Set([" ", "\t", "\n"]);
 
 function isAlpha(c: string) {

--- a/src/ast/state/ParserState.ts
+++ b/src/ast/state/ParserState.ts
@@ -7,6 +7,10 @@ function isAlpha(c: string) {
   return /^[a-zA-Z]$/.test(c);
 }
 
+function isNumeric(c: string) {
+  return /^[0-9]$/.test(c);
+}
+
 export class ParserState {
   private index = 0;
   private _token: string = "";
@@ -58,6 +62,11 @@ export class ParserState {
       return;
     }
 
+    if (isNumeric(c)) {
+      this.nextNumericToken(c);
+      return;
+    }
+
     if (isAlpha(c)) {
       this.nextSymbolToken(c);
       return;
@@ -78,6 +87,20 @@ export class ParserState {
       c = this.currentCharacter();
     }
     this._tokenType = TokenType.Symbol;
+    this._token = s;
+  }
+
+  /**
+   * @todo support decimals
+   */
+  private nextNumericToken(c: string) {
+    let s = "";
+    while (isNumeric(c)) {
+      s += c;
+      this.next();
+      c = this.currentCharacter();
+    }
+    this._tokenType = TokenType.Number;
     this._token = s;
   }
 

--- a/src/ast/token.ts
+++ b/src/ast/token.ts
@@ -2,4 +2,5 @@ export enum TokenType {
   None = 0,
   Delimeter = 1,
   Symbol = 2,
+  Number = 3,
 }

--- a/src/compile/compileSchema.spec.ts
+++ b/src/compile/compileSchema.spec.ts
@@ -41,7 +41,7 @@ describe("compileSchema", () => {
     try {
       schema.parseSync({ a: "string" });
     } catch (e) {
-      thrown = e;
+      thrown = e as ValidationError;
     }
 
     expect(thrown.message).toEqual("Expected number value, got string");
@@ -54,7 +54,7 @@ describe("compileSchema", () => {
     try {
       schema.parseSync({ a: { b: [0, 1, "2"] } });
     } catch (e) {
-      thrown = e;
+      thrown = e as ValidationError;
     }
 
     expect(thrown.path).toEqual("a.b[2]");
@@ -67,7 +67,7 @@ describe("compileSchema", () => {
     try {
       schema.parseSync({ a: { b: [0, 1, "2"] } });
     } catch (e) {
-      thrown = e;
+      thrown = e as ValidationError;
     }
 
     expect(thrown.value).toEqual("2");
@@ -80,7 +80,7 @@ describe("compileSchema", () => {
     try {
       schema.parseSync({ a: "string" });
     } catch (e) {
-      thrown = e;
+      thrown = e as ValidationError;
     }
 
     expect(thrown instanceof ValidationError).toEqual(true);

--- a/src/types/Ast.ts
+++ b/src/types/Ast.ts
@@ -1,7 +1,9 @@
+import { Rule } from "./Rule";
+
 export interface PrimitiveNode {
   type: "primitive";
   valueType: PrimitiveType;
-  // Eventually, we will add rules here
+  rules: Rule[];
 }
 
 export type PrimitiveType = "string" | "number";

--- a/src/types/Ast.ts
+++ b/src/types/Ast.ts
@@ -1,8 +1,10 @@
 export interface PrimitiveNode {
   type: "primitive";
-  valueType: "string" | "number";
+  valueType: PrimitiveType;
   // Eventually, we will add rules here
 }
+
+export type PrimitiveType = "string" | "number";
 
 export interface PropertyNode {
   type: "property";

--- a/src/types/Rule.ts
+++ b/src/types/Rule.ts
@@ -1,10 +1,17 @@
-export type StringRule = { type: "email" };
+export type StringEmailRule = { type: "email" };
+
+export type StringRule = StringEmailRule;
+
+export type NumberIntRule = { type: "int" };
+export type NumberPositiveRule = { type: "positive" };
+export type NumberMaxRule = { type: "max"; value: number };
+export type NumberMinRule = { type: "min"; value: number };
 
 export type NumberRule =
-  | { type: "int" }
-  | { type: "positive" }
-  | { type: "min"; value: number }
-  | { type: "max"; value: number };
+  | NumberIntRule
+  | NumberPositiveRule
+  | NumberMinRule
+  | NumberMaxRule;
 
 export type Rule = StringRule | NumberRule;
 

--- a/src/types/Rule.ts
+++ b/src/types/Rule.ts
@@ -1,3 +1,9 @@
 export type StringRule = { type: "email" };
 
-export type NumberRule = { type: "integer" } | { type: "positive" };
+export type NumberRule =
+  | { type: "integer" }
+  | { type: "positive" }
+  | { type: "min"; value: number }
+  | { type: "max"; value: number };
+
+export type Rule = StringRule | NumberRule;

--- a/src/types/Rule.ts
+++ b/src/types/Rule.ts
@@ -1,7 +1,7 @@
 export type StringRule = { type: "email" };
 
 export type NumberRule =
-  | { type: "integer" }
+  | { type: "int" }
   | { type: "positive" }
   | { type: "min"; value: number }
   | { type: "max"; value: number };

--- a/src/types/Rule.ts
+++ b/src/types/Rule.ts
@@ -7,3 +7,5 @@ export type NumberRule =
   | { type: "max"; value: number };
 
 export type Rule = StringRule | NumberRule;
+
+export type RuleType = Rule["type"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**/*.spec.ts",
     "src/**/*.typecheck.ts",
   ]
 }


### PR DESCRIPTION
# Scope

This PR implements parsing rules (generating the AST), but not enforcing them (validating incoming data). Enforcing rules will be implemented in a separate PR.

# Changes

## Parse rules

Added `~/ast/parse/rules.ts`

It exports `parseRules`, which is used by `parseProperty`:

```tsx
const value = parseValue(state);
const isArray = parseIsArray(state);

if (value.type === "primitive") {
  value.rules = parseRules(state, value.valueType);
}
```


## Add `TokenType.Number`

It is encountered when parsing arguments to rules:

```
rating: number <min(1), max(5)>;
```


## Add tests for `~/ast/parse/property.ts`

We are testing both old and new behavior related to parsing properties (for both `parseProperty` and `parseProperties`).

