### PR TITLE
Optional by default

### DIFF
--- a/src/types/Parse.ts
+++ b/src/types/Parse.ts
@@ -22,6 +22,8 @@ type ParseToken<T extends string> = T extends Primitive
       [`Expected one of [${StringJoin<PrimitivesTuple, ", ">}] but got '${T}'`]
     >;
 
+type Optional<T> = T extends Err<infer E> ? T : T | null;
+
 type FindValue<T extends string> =
   // Array of objects
   T extends `Array<{${infer R}}>`
@@ -37,12 +39,20 @@ type FindValue<T extends string> =
     T extends `${infer Token}[]<${string}>`
     ? ParseToken<Token>[]
     : //
-    // Primitive with rules
-    T extends `${infer Token}<${string}>`
+    // Primitive with rules and a default
+    T extends `${infer Token}<${string}>=${string}`
     ? ParseToken<Token>
     : //
+    // Primitive with default
+    T extends `${infer Token}=${string}`
+    ? ParseToken<Token>
+    : //
+    // Primitive with rules
+    T extends `${infer Token}<${string}>`
+    ? Optional<ParseToken<Token>>
+    : //
       // When none of the above matched, we expect to find just a primitive
-      ParseToken<T>;
+      Optional<ParseToken<T>>;
 
 type KeyValue<T extends string> = T extends `${infer K}:${infer Rest}`
   ? {

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -25,6 +25,8 @@ it("parses an object with multiple properties", () => [
 it("makes fields required if a default value is provided", () => [
   eq<Parse<`{ a: string = "Hello" }`>, { a: string }>(),
   eq<Parse<`{ a: { b: string = "Hello" } }`>, { a: { b: string } }>(),
+  eq<Parse<`{ a: boolean = true }`>, { a: boolean }>(),
+  eq<Parse<`{ a: number = 42 }`>, { a: number }>(),
 ]);
 
 it("deals with problem characters in default values", () => [

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -22,6 +22,36 @@ it("parses an object with multiple properties", () => [
   >(),
 ]);
 
+it("makes fields required if a default value is provided", () => [
+  eq<Parse<`{ a: string = "Hello" }`>, { a: string }>(),
+  eq<Parse<`{ a: { b: string = "Hello" } }`>, { a: { b: string } }>(),
+]);
+
+it("deals with problem characters in default values", () => [
+  eq<Parse<`{ a: string = ";"; b: number = 42 }`>, { a: string; b: number }>(),
+  eq<
+    Parse<`{ a: string = ";a:{}"; b: number = 42 }`>,
+    { a: string; b: number }
+  >(),
+  eq<
+    Parse<`{ a: string <rules> = ";<>"; b: number = 42 }`>,
+    { a: string; b: number }
+  >(),
+  eq<
+    Parse<`{ a: string = "'a;:{}"; b: number = 42 }`>,
+    { a: string; b: number }
+  >(),
+
+  /**
+   * @todo We do not have a good way to deal with double quotes within
+   * string values yet.
+   */
+  not_eq<
+    Parse<`{ a: string = "";"; b: number = 42 }`>,
+    { a: string; b: number }
+  >(),
+]);
+
 it("does not require a trailing ';'", () => [
   eq<
     Parse<`{ a: string; b: number }`>,

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -12,15 +12,21 @@ it("returns an error if the string does not match '{...}'", () => [
 it("parses an empty object", () => [eq<Parse<`{}`>, {}>()]);
 
 it("parses an object with a single property", () => [
-  eq<Parse<`{ a: string; }`>, { a: string }>(),
+  eq<Parse<`{ a: string; }`>, { a: string | null }>(),
 ]);
 
 it("parses an object with multiple properties", () => [
-  eq<Parse<`{ a: string; b: number; }`>, { a: string; b: number }>(),
+  eq<
+    Parse<`{ a: string; b: number; }`>,
+    { a: string | null; b: number | null }
+  >(),
 ]);
 
 it("does not require a trailing ';'", () => [
-  eq<Parse<`{ a: string; b: number }`>, { a: string; b: number }>(),
+  eq<
+    Parse<`{ a: string; b: number }`>,
+    { a: string | null; b: number | null }
+  >(),
 ]);
 
 it("requires a ';' beween properties", () => [
@@ -28,7 +34,10 @@ it("requires a ';' beween properties", () => [
    * @todo improve the error message for ',' between properties
    * @todo match the specific error that occurs
    */
-  not_eq<Parse<`{ a: string, b: number }`>, { a: string; b: number }>(),
+  not_eq<
+    Parse<`{ a: string, b: number }`>,
+    { a: string | null; b: number | null }
+  >(),
 ]);
 
 it("parses arrays of primitives", () => [
@@ -58,24 +67,27 @@ it("parses objects as properties", () => [eq<Parse<`{ a: {} }`>, { a: {} }>()]);
 
 it("parses arrays of objects as properties", () => [
   // Array literal syntax
-  eq<Parse<`{ a: { b: number }[] }`>, { a: Array<{ b: number }> }>(),
+  eq<Parse<`{ a: { b: number }[] }`>, { a: Array<{ b: number | null }> }>(),
 
   // Named array syntax
-  eq<Parse<`{ a: Array<{ b: number }> }`>, { a: Array<{ b: number }> }>(),
+  eq<
+    Parse<`{ a: Array<{ b: number }> }`>,
+    { a: Array<{ b: number | null }> }
+  >(),
 ]);
 
 it("parses nested object properties", () => [
   eq<Parse<`{ a: { b: {} } }`>, { a: { b: {} } }>(),
   eq<
     Parse<`{ a: { b: string; c: { d: number } } }`>,
-    { a: { b: string; c: { d: number } } }
+    { a: { b: string | null; c: { d: number | null } } }
   >(),
 ]);
 
 it("parses multiple object properties", () => [
   eq<
     Parse<`{ a: { b: { c: number } }; d: { e: {}; f: {} } }`>,
-    { a: { b: { c: number } }; d: { e: {}; f: {} } }
+    { a: { b: { c: number | null } }; d: { e: {}; f: {} } }
   >(),
 ]);
 


### PR DESCRIPTION
Relates to #14 

This PR implements the change mentioned in #14 related to making fields optional by default and adding support for default values in the `Parse` type.

Implementing optional by-default and default values for `compileSchema` will be done in a separate PR.
