### PR TITLE
Parse Default Value

### DIFF
--- a/src/ast/astFromString.spec.ts
+++ b/src/ast/astFromString.spec.ts
@@ -17,7 +17,12 @@ describe("astFromString", () => {
         {
           type: "property",
           key: "a",
-          value: { type: "primitive", valueType: "string", rules: [] },
+          value: {
+            type: "primitive",
+            valueType: "string",
+            rules: [],
+            defaultValue: null,
+          },
         },
       ],
     };
@@ -33,12 +38,22 @@ describe("astFromString", () => {
         {
           type: "property",
           key: "a",
-          value: { type: "primitive", valueType: "string", rules: [] },
+          value: {
+            type: "primitive",
+            valueType: "string",
+            rules: [],
+            defaultValue: null,
+          },
         },
         {
           type: "property",
           key: "b",
-          value: { type: "primitive", valueType: "number", rules: [] },
+          value: {
+            type: "primitive",
+            valueType: "number",
+            rules: [],
+            defaultValue: null,
+          },
         },
       ],
     };
@@ -67,7 +82,12 @@ describe("astFromString", () => {
               {
                 type: "property",
                 key: "b",
-                value: { type: "primitive", valueType: "string", rules: [] },
+                value: {
+                  type: "primitive",
+                  valueType: "string",
+                  rules: [],
+                  defaultValue: null,
+                },
               },
             ],
           },
@@ -102,6 +122,7 @@ describe("astFromString", () => {
                         type: "primitive",
                         valueType: "string",
                         rules: [],
+                        defaultValue: null,
                       },
                     },
                   ],
@@ -126,7 +147,12 @@ describe("astFromString", () => {
           key: "a",
           value: {
             type: "array",
-            value: { type: "primitive", valueType: "string", rules: [] },
+            value: {
+              type: "primitive",
+              valueType: "string",
+              rules: [],
+              defaultValue: null,
+            },
           },
         },
       ],
@@ -151,7 +177,12 @@ describe("astFromString", () => {
                 {
                   type: "property",
                   key: "b",
-                  value: { type: "primitive", valueType: "string", rules: [] },
+                  value: {
+                    type: "primitive",
+                    valueType: "string",
+                    rules: [],
+                    defaultValue: null,
+                  },
                 },
               ],
             },

--- a/src/ast/parse/defaultValue.spec.ts
+++ b/src/ast/parse/defaultValue.spec.ts
@@ -1,0 +1,20 @@
+import { ParserState } from "../state/ParserState";
+import { parseDefaultValue } from "./defaultValue";
+
+describe("parseDefaultValue", () => {
+  it("parses a string default value", () => {
+    const state = new ParserState(`="Hello, world"`);
+
+    const value = parseDefaultValue(state, "string");
+
+    expect(value).toEqual("Hello, world");
+  });
+
+  it("handles escaped in string default values", () => {
+    const state = new ParserState(`="Hello, \\"world\\""`);
+
+    const value = parseDefaultValue(state, "string");
+
+    expect(value).toEqual('Hello, "world"');
+  });
+});

--- a/src/ast/parse/defaultValue.spec.ts
+++ b/src/ast/parse/defaultValue.spec.ts
@@ -2,6 +2,18 @@ import { ParserState } from "../state/ParserState";
 import { parseDefaultValue } from "./defaultValue";
 
 describe("parseDefaultValue", () => {
+  it("returns null if the next token is not '='", () => {
+    const templates = [`"Hello, world"`, `<rules>`, `; a: string;`];
+
+    for (const template of templates) {
+      const state = new ParserState(template);
+
+      const value = parseDefaultValue(state, "string");
+
+      expect(value).toEqual(null);
+    }
+  });
+
   it("parses a string default value", () => {
     const state = new ParserState(`= "Hello, world"`);
 

--- a/src/ast/parse/defaultValue.spec.ts
+++ b/src/ast/parse/defaultValue.spec.ts
@@ -22,7 +22,7 @@ describe("parseDefaultValue", () => {
     expect(value).toEqual("Hello, world");
   });
 
-  it("handles escaped in string default values", () => {
+  it("handles escaped double quotes in string default values", () => {
     const state = new ParserState(`= "Hello, \\"world\\""`);
 
     const value = parseDefaultValue(state, "string");

--- a/src/ast/parse/defaultValue.spec.ts
+++ b/src/ast/parse/defaultValue.spec.ts
@@ -54,6 +54,30 @@ describe("parseDefaultValue", () => {
     expect(value).toEqual(false);
   });
 
+  it("moves to the next token after parsing the default value", () => {
+    const cases = [
+      [`= "Hello";`, "string"],
+      [`= 42;`, "number"],
+      [`= true;`, "boolean"],
+    ] as const;
+
+    for (const [template, type] of cases) {
+      const state = new ParserState(template);
+
+      parseDefaultValue(state, type);
+
+      expect(state.token()).toEqual(";");
+    }
+  });
+
+  it("does not modify the state if there is no default value to be parsed", () => {
+    const state = new ParserState(`;`);
+
+    parseDefaultValue(state, "string");
+
+    expect(state.token()).toEqual(";");
+  });
+
   it("throws if an incorrect default value for a string is provided", () => {
     const numberState = new ParserState(`= 42`);
     const booleanState = new ParserState(`= true`);

--- a/src/ast/parse/defaultValue.spec.ts
+++ b/src/ast/parse/defaultValue.spec.ts
@@ -3,7 +3,7 @@ import { parseDefaultValue } from "./defaultValue";
 
 describe("parseDefaultValue", () => {
   it("parses a string default value", () => {
-    const state = new ParserState(`="Hello, world"`);
+    const state = new ParserState(`= "Hello, world"`);
 
     const value = parseDefaultValue(state, "string");
 
@@ -11,10 +11,67 @@ describe("parseDefaultValue", () => {
   });
 
   it("handles escaped in string default values", () => {
-    const state = new ParserState(`="Hello, \\"world\\""`);
+    const state = new ParserState(`= "Hello, \\"world\\""`);
 
     const value = parseDefaultValue(state, "string");
 
     expect(value).toEqual('Hello, "world"');
+  });
+
+  it("parses a number default value", () => {
+    const state = new ParserState(`= 42`);
+
+    const value = parseDefaultValue(state, "number");
+
+    expect(value).toEqual(42);
+  });
+
+  it("parses a number default value", () => {
+    const state = new ParserState(`= 42`);
+
+    const value = parseDefaultValue(state, "number");
+
+    expect(value).toEqual(42);
+  });
+
+  it("parses a boolean default value", () => {
+    const state = new ParserState(`= false`);
+
+    const value = parseDefaultValue(state, "boolean");
+
+    expect(value).toEqual(false);
+  });
+
+  it("throws if an incorrect default value for a string is provided", () => {
+    const numberState = new ParserState(`= 42`);
+    const booleanState = new ParserState(`= true`);
+
+    const parseNumber = () => parseDefaultValue(numberState, "string");
+    const parseBoolean = () => parseDefaultValue(booleanState, "string");
+
+    expect(parseNumber).toThrow("Expected string, got '42'");
+    expect(parseBoolean).toThrow("Expected string, got 'true'");
+  });
+
+  it("throws if an incorrect default value for a number is provided", () => {
+    const stringState = new ParserState(`= "42"`);
+    const booleanState = new ParserState(`= true`);
+
+    const parseString = () => parseDefaultValue(stringState, "number");
+    const parseBoolean = () => parseDefaultValue(booleanState, "number");
+
+    expect(parseString).toThrow("Expected number, got '\"42\"'");
+    expect(parseBoolean).toThrow("Expected number, got 'true'");
+  });
+
+  it("throws if an incorrect default value for a boolean is provided", () => {
+    const stringState = new ParserState(`= "Hello, world"`);
+    const numberState = new ParserState(`= 42`);
+
+    const parseString = () => parseDefaultValue(stringState, "boolean");
+    const parseNumber = () => parseDefaultValue(numberState, "boolean");
+
+    expect(parseString).toThrow("Expected boolean, got '\"Hello, world\"'");
+    expect(parseNumber).toThrow("Expected boolean, got '42'");
   });
 });

--- a/src/ast/parse/defaultValue.ts
+++ b/src/ast/parse/defaultValue.ts
@@ -64,6 +64,8 @@ export function parseDefaultValue(
   const token = state.token();
   const tokenType = state.tokenType();
 
+  state.nextToken();
+
   switch (primitiveType) {
     case "string":
       return parseString(token, tokenType);

--- a/src/ast/parse/defaultValue.ts
+++ b/src/ast/parse/defaultValue.ts
@@ -5,7 +5,7 @@ import { TokenType } from "../token";
 
 function parseString(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.String) {
-    throw new Error(`Expected string, got ${tokenType} '${token}'`);
+    throw new Error(`Expected string, got '${token}'`);
   }
 
   return token;
@@ -13,7 +13,7 @@ function parseString(token: string, tokenType: TokenType) {
 
 function parseNumber(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.Number) {
-    throw new Error(`Expected number, got ${tokenType} '${token}'`);
+    throw new Error(`Expected number, got '${token}'`);
   }
 
   const value = Number(token);
@@ -27,7 +27,7 @@ function parseNumber(token: string, tokenType: TokenType) {
 
 function parseBoolean(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.Symbol) {
-    throw new Error(`Expected boolean, got ${tokenType} '${token}'`);
+    throw new Error(`Expected boolean, got '${token}'`);
   }
 
   switch (token) {

--- a/src/ast/parse/defaultValue.ts
+++ b/src/ast/parse/defaultValue.ts
@@ -3,6 +3,14 @@ import { Primitive } from "../../types/Primitive";
 import { ParserState } from "../state/ParserState";
 import { TokenType } from "../token";
 
+// So that the error message prints quotes around the value (like '"..."')
+function quoteIfString(token: string, tokenType: TokenType) {
+  if (tokenType === TokenType.String) {
+    token = `"${token}"`;
+  }
+  return token;
+}
+
 function parseString(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.String) {
     throw new Error(`Expected string, got '${token}'`);
@@ -13,7 +21,9 @@ function parseString(token: string, tokenType: TokenType) {
 
 function parseNumber(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.Number) {
-    throw new Error(`Expected number, got '${token}'`);
+    throw new Error(
+      `Expected number, got '${quoteIfString(token, tokenType)}'`
+    );
   }
 
   const value = Number(token);
@@ -27,7 +37,9 @@ function parseNumber(token: string, tokenType: TokenType) {
 
 function parseBoolean(token: string, tokenType: TokenType) {
   if (tokenType !== TokenType.Symbol) {
-    throw new Error(`Expected boolean, got '${token}'`);
+    throw new Error(
+      `Expected boolean, got '${quoteIfString(token, tokenType)}'`
+    );
   }
 
   switch (token) {

--- a/src/ast/parse/defaultValue.ts
+++ b/src/ast/parse/defaultValue.ts
@@ -1,0 +1,65 @@
+import { enforceExhaustive } from "../../switch";
+import { Primitive } from "../../types/Primitive";
+import { ParserState } from "../state/ParserState";
+import { TokenType } from "../token";
+
+function parseString(token: string, tokenType: TokenType) {
+  if (tokenType !== TokenType.String) {
+    throw new Error(`Expected string, got ${tokenType} '${token}'`);
+  }
+
+  return token;
+}
+
+function parseNumber(token: string, tokenType: TokenType) {
+  if (tokenType !== TokenType.Number) {
+    throw new Error(`Expected number, got ${tokenType} '${token}'`);
+  }
+
+  const value = Number(token);
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`Expected finite number, got '${value}'`);
+  }
+
+  return value;
+}
+
+function parseBoolean(token: string, tokenType: TokenType) {
+  if (tokenType !== TokenType.Symbol) {
+    throw new Error(`Expected boolean, got ${tokenType} '${token}'`);
+  }
+
+  switch (token) {
+    case "true":
+      return true;
+    case "false":
+      return false;
+    default:
+      throw new Error(`Unexpected token '${token}', expected true or false`);
+  }
+}
+
+export function parseDefaultValue(
+  state: ParserState,
+  primitiveType: Primitive
+): unknown {
+  if (!state.atDelimeter("=")) {
+    return null;
+  }
+  state.nextToken();
+
+  const token = state.token();
+  const tokenType = state.tokenType();
+
+  switch (primitiveType) {
+    case "string":
+      return parseString(token, tokenType);
+    case "number":
+      return parseNumber(token, tokenType);
+    case "boolean":
+      return parseBoolean(token, tokenType);
+    default:
+      enforceExhaustive(primitiveType, "Unexpected primitive type");
+  }
+}

--- a/src/ast/parse/property.ts
+++ b/src/ast/parse/property.ts
@@ -1,6 +1,7 @@
 import { PropertyNode } from "../../types/Ast";
 import { ParserState } from "../state/ParserState";
 import { TokenType } from "../token";
+import { parseDefaultValue } from "./defaultValue";
 import { parseRules } from "./rules";
 import { parseValue } from "./value";
 
@@ -48,6 +49,7 @@ export function parseProperty(state: ParserState): PropertyNode {
 
   if (value.type === "primitive") {
     value.rules = parseRules(state, value.valueType);
+    value.defaultValue = parseDefaultValue(state, value.valueType);
   }
 
   const property: PropertyNode = { type: "property", key, value };

--- a/src/ast/parse/value.ts
+++ b/src/ast/parse/value.ts
@@ -43,6 +43,7 @@ export function parseValue(state: ParserState): ValueNode {
     case TokenType.None:
       throw new Error(`Expected end of template`);
     case TokenType.Number:
+    case TokenType.String:
       throw new Error(`Unexpected token type '${tokenType}'`);
     default:
       enforceExhaustive(tokenType, `Unexpected token type`);

--- a/src/ast/parse/value.ts
+++ b/src/ast/parse/value.ts
@@ -28,6 +28,7 @@ export function parseValue(state: ParserState): ValueNode {
         type: "primitive",
         valueType: token,
         rules: [], // The rules are added later in 'parseProperty'
+        defaultValue: null, // The default value is added later in 'parseProperty'
       };
       state.nextToken();
       break;

--- a/src/ast/state/ParserState.ts
+++ b/src/ast/state/ParserState.ts
@@ -12,6 +12,8 @@ const delimeters = new Set([
   "(",
   ")",
   ",",
+  "=",
+  '"',
 ]);
 const whitespace = new Set([" ", "\t", "\n"]);
 
@@ -69,6 +71,11 @@ export class ParserState {
 
     const c = this.currentCharacter();
 
+    if (c === '"') {
+      this.nextStringToken();
+      return;
+    }
+
     if (delimeters.has(c)) {
       this.nextDelimeterToken(c);
       return;
@@ -89,6 +96,10 @@ export class ParserState {
 
   private currentCharacter() {
     return this.s.substr(this.index, 1);
+  }
+
+  private characterAtOffset(offset: number) {
+    return this.s.substr(this.index + offset, 1);
   }
 
   private nextSymbolToken(c: string) {
@@ -113,6 +124,35 @@ export class ParserState {
       c = this.currentCharacter();
     }
     this._tokenType = TokenType.Number;
+    this._token = s;
+  }
+
+  private nextStringToken() {
+    this.next();
+
+    let s = "";
+    let c = this.currentCharacter();
+
+    while (true) {
+      if (c === "") {
+        throw new Error("Unexpected end of template");
+      }
+
+      if (c === '"') {
+        this.next();
+        break;
+      }
+
+      if (c === "\\" && this.characterAtOffset(1) === '"') {
+        c = '"';
+        this.next();
+      }
+
+      s += c;
+      this.next();
+      c = this.currentCharacter();
+    }
+    this._tokenType = TokenType.String;
     this._token = s;
   }
 

--- a/src/ast/token.ts
+++ b/src/ast/token.ts
@@ -3,4 +3,5 @@ export enum TokenType {
   Delimeter = 1,
   Symbol = 2,
   Number = 3,
+  String = 4,
 }

--- a/src/compile/compileSchema.ts
+++ b/src/compile/compileSchema.ts
@@ -4,13 +4,14 @@ import { Schema } from "../types/Schema";
 import { validateObject } from "../validate/object";
 import { copyObject } from "../copy/copyObject";
 import { typeAsString } from "../format/typeAsString";
+import { isPlainObject } from "../validate/utils/isPlainObject";
 
 export function compileSchema<T extends string>(template: T): Schema<Parse<T>> {
   const ast = astFromString(template);
 
   const schema: Schema<Parse<T>> = {
     parseSync: (value) => {
-      if (typeof value !== "object" || !value) {
+      if (!isPlainObject(value)) {
         throw new Error(`Expected object, got '${typeAsString(value)}'`);
       }
 

--- a/src/compile/compileSchema.ts
+++ b/src/compile/compileSchema.ts
@@ -3,12 +3,17 @@ import { Parse } from "../types/Parse";
 import { Schema } from "../types/Schema";
 import { validateObject } from "../validate/object";
 import { copyObject } from "../copy/copyObject";
+import { typeAsString } from "../format/typeAsString";
 
 export function compileSchema<T extends string>(template: T): Schema<Parse<T>> {
   const ast = astFromString(template);
 
   const schema: Schema<Parse<T>> = {
     parseSync: (value) => {
+      if (typeof value !== "object" || !value) {
+        throw new Error(`Expected object, got '${typeAsString(value)}'`);
+      }
+
       const err = validateObject(value, ast.properties, { path: [] });
       if (err) {
         throw err;

--- a/src/copy/copyObject.spec.ts
+++ b/src/copy/copyObject.spec.ts
@@ -30,6 +30,15 @@ describe("copyObject", () => {
     expect(copied).toHaveProperty("c");
   });
 
+  it("creates a new object for object properties", () => {
+    const ast = astFromString(`{ a: {}; }`);
+    const original = { a: {} };
+
+    const copied: any = copyObject(original, ast);
+
+    expect(copied.a === original.a).toEqual(false);
+  });
+
   it("initializes primitives that are not present with null", () => {
     const ast = astFromString(`{ a: string; b: number; c: boolean }`);
 

--- a/src/copy/copyObject.spec.ts
+++ b/src/copy/copyObject.spec.ts
@@ -1,0 +1,146 @@
+import { astFromString } from "../ast/astFromString";
+import { copyObject } from "./copyObject";
+
+describe("copyObject", () => {
+  it("creates a new object", () => {
+    const ast = astFromString(`{ a: string; }`);
+    const original = { a: "Hello" };
+
+    const copied = copyObject(original, ast);
+
+    expect(copied === original).toEqual(false);
+  });
+
+  it("copies primitives", () => {
+    const ast = astFromString(`{ a: string; b: number; c: boolean }`);
+    const original = { a: "Hello", b: 1, c: true };
+
+    const copied = copyObject(original, ast);
+
+    expect(copied).toEqual(original);
+  });
+
+  it("copies every key, even if not in the original object", () => {
+    const ast = astFromString(`{ a: string; b: number; c: boolean }`);
+
+    const copied = copyObject({}, ast);
+
+    expect(copied).toHaveProperty("a");
+    expect(copied).toHaveProperty("b");
+    expect(copied).toHaveProperty("c");
+  });
+
+  it("initializes primitives that are not present with null", () => {
+    const ast = astFromString(`{ a: string; b: number; c: boolean }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.a).toEqual(null);
+    expect(copied.b).toEqual(null);
+    expect(copied.c).toEqual(null);
+  });
+
+  it("uses the default value when the property is not provided", () => {
+    const ast = astFromString(`{ value: number = 42 }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.value).toEqual(42);
+  });
+
+  it("does not override the value with the default if provided", () => {
+    const ast = astFromString(`{ value: number = 42 }`);
+
+    const copied: any = copyObject({ value: 1 }, ast);
+
+    expect(copied.value).toEqual(1);
+  });
+
+  it("does not override a falsy value with the default if provided", () => {
+    const ast = astFromString(`{ value: number = 42 }`);
+
+    const copied: any = copyObject({ value: 0 }, ast);
+
+    expect(copied.value).toEqual(0);
+  });
+
+  it("overrides null values with the default", () => {
+    const ast = astFromString(`{ value: number = 42 }`);
+
+    const copied: any = copyObject({ value: null }, ast);
+
+    expect(copied.value).toEqual(42);
+  });
+
+  it("overrides undefined values with the default", () => {
+    const ast = astFromString(`{ value: number = 42 }`);
+
+    const copied: any = copyObject({ value: undefined }, ast);
+
+    expect(copied.value).toEqual(42);
+  });
+
+  it("initializes arrays with empty arrays if not provided", () => {
+    const ast = astFromString(`{ ints: number[] }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.ints).toEqual([]);
+  });
+
+  it("initializes arrays with empty arrays if null is provided", () => {
+    const ast = astFromString(`{ ints: number[] }`);
+
+    const copied: any = copyObject({ ints: null }, ast);
+
+    expect(copied.ints).toEqual([]);
+  });
+
+  it("initializes arrays with empty arrays if undefined is provided", () => {
+    const ast = astFromString(`{ ints: number[] }`);
+
+    const copied: any = copyObject({ ints: undefined }, ast);
+
+    expect(copied.ints).toEqual([]);
+  });
+
+  it("initializes objects if not provided", () => {
+    const ast = astFromString(`{ obj: {} }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.obj).toEqual({});
+  });
+
+  it("initializes objects if null is provided", () => {
+    const ast = astFromString(`{ obj: {} }`);
+
+    const copied: any = copyObject({ obj: null }, ast);
+
+    expect(copied.obj).toEqual({});
+  });
+
+  it("initializes objects if undefined is provided", () => {
+    const ast = astFromString(`{ obj: {} }`);
+
+    const copied: any = copyObject({ obj: undefined }, ast);
+
+    expect(copied.obj).toEqual({});
+  });
+
+  it("initializes properties of objects if the object is not provided", () => {
+    const ast = astFromString(`{ obj: { value: number } }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.obj).toEqual({ value: null });
+  });
+
+  it("initializes properties of objects with their default values if the object is not provided", () => {
+    const ast = astFromString(`{ obj: { value: number = 42 } }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied.obj).toEqual({ value: 42 });
+  });
+});

--- a/src/copy/copyObject.ts
+++ b/src/copy/copyObject.ts
@@ -9,9 +9,9 @@ function copyProperty(value: unknown, ast: ValueNode): unknown {
       if (isNullOrUndefined) return ast.defaultValue;
       return value;
     case "object":
-      return copyObject(value, ast);
+      return copyObject(value || {}, ast);
     case "array":
-      return copyArray(value as unknown[], ast);
+      return copyArray((value as unknown[]) || [], ast);
     default:
       enforceExhaustive(type, "Unexpected type");
   }

--- a/src/copy/copyObject.ts
+++ b/src/copy/copyObject.ts
@@ -5,6 +5,8 @@ function copyProperty(value: unknown, ast: ValueNode): unknown {
   const { type } = ast;
   switch (type) {
     case "primitive":
+      const isNullOrUndefined = typeof value === "undefined" || value === null;
+      if (isNullOrUndefined) return ast.defaultValue;
       return value;
     case "object":
       return copyObject(value, ast);

--- a/src/copy/copyObject.ts
+++ b/src/copy/copyObject.ts
@@ -1,12 +1,12 @@
 import { enforceExhaustive } from "../switch";
 import { ArrayNode, ObjectNode, ValueNode } from "../types/Ast";
+import { isNullOrUndefined } from "../validate/utils/isNullOrUndefined";
 
 function copyProperty(value: unknown, ast: ValueNode): unknown {
   const { type } = ast;
   switch (type) {
     case "primitive":
-      const isNullOrUndefined = typeof value === "undefined" || value === null;
-      if (isNullOrUndefined) return ast.defaultValue;
+      if (isNullOrUndefined(value)) return ast.defaultValue;
       return value;
     case "object":
       return copyObject(value || {}, ast);

--- a/src/types/Ast.ts
+++ b/src/types/Ast.ts
@@ -5,6 +5,7 @@ export interface PrimitiveNode {
   type: "primitive";
   valueType: Primitive;
   rules: Rule[];
+  defaultValue: unknown;
 }
 
 export interface PropertyNode {

--- a/src/types/Parse.ts
+++ b/src/types/Parse.ts
@@ -91,7 +91,9 @@ type _Parse<T extends string> = T extends `{${infer Content}}`
   : Err<[`Expected {...}, got '${T}'`]>;
 
 type RemoveProblemCharactersInStringValues<T extends string> =
-  T extends `${infer Before}:string<${infer Rules}>="${infer _}"${infer After}`
+  T extends `${infer Before}\\"${infer After}`
+    ? RemoveProblemCharactersInStringValues<`${Before}${After}`>
+    : T extends `${infer Before}:string<${infer Rules}>="${infer _}"${infer After}`
     ? RemoveProblemCharactersInStringValues<`${Before}:string<${Rules}>=_${After}`>
     : T extends `${infer Before}:string="${infer _}"${infer After}`
     ? RemoveProblemCharactersInStringValues<`${Before}:string=_${After}`>

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -43,13 +43,11 @@ it("deals with problem characters in default values", () => [
     Parse<`{ a: string = "'a;:{}"; b: number = 42 }`>,
     { a: string; b: number }
   >(),
+]);
 
-  /**
-   * @todo We do not have a good way to deal with double quotes within
-   * string values yet.
-   */
-  not_eq<
-    Parse<`{ a: string = "";"; b: number = 42 }`>,
+it("allows double quotes to be escaped via '\\\"'", () => [
+  eq<
+    Parse<`{ a: string = "\\";"; b: number = 42 }`>,
     { a: string; b: number }
   >(),
 ]);

--- a/src/validate/array.ts
+++ b/src/validate/array.ts
@@ -4,6 +4,7 @@ import { ArrayNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
 import { validateObject } from "./object";
 import { validatePrimitive } from "./primitive";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
 
 export function validateArray(
@@ -11,9 +12,7 @@ export function validateArray(
   spec: ArrayNode,
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = arr === undefined || arr === null;
-
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(arr)) {
     return null;
   }
 

--- a/src/validate/boolean.spec.ts
+++ b/src/validate/boolean.spec.ts
@@ -13,6 +13,14 @@ describe("validateBoolean", () => {
     }
   });
 
+  it("accepts null or undefined values", () => {
+    const values = [null, undefined];
+
+    for (const value of values) {
+      expect(parse(value)).not.toThrow();
+    }
+  });
+
   it("rejects non-boolean values", () => {
     const values = ["Hello", 1, { value: true }, [true]];
 
@@ -21,5 +29,24 @@ describe("validateBoolean", () => {
         `Expected boolean value, got ${typeAsString(value)}`
       );
     }
+  });
+
+  it("returns null if no default is present and the value is null or undefined", () => {
+    const schema = compileSchema(`{ value: boolean; }`);
+    const values = [null, undefined];
+
+    for (const value of values) {
+      const parsed = schema.parseSync({ value });
+
+      expect(parsed.value).toEqual(null);
+    }
+  });
+
+  it("returns the default value for a boolean", () => {
+    const schema = compileSchema(`{ value: boolean = true; }`);
+
+    const { value } = schema.parseSync({ value: null });
+
+    expect(value).toEqual(true);
   });
 });

--- a/src/validate/boolean.ts
+++ b/src/validate/boolean.ts
@@ -1,13 +1,13 @@
 import { typeAsString } from "../format/typeAsString";
 import { ValidationContext } from "../types/ValidationContext";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
 
 export function validateBoolean(
   value: unknown,
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = value === undefined || value === null;
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(value)) {
     return null;
   }
 

--- a/src/validate/number.ts
+++ b/src/validate/number.ts
@@ -2,6 +2,7 @@ import { typeAsString } from "../format/typeAsString";
 import { NumberRule } from "../types/Rule";
 import { ValidationContext } from "../types/ValidationContext";
 import { validateNumberRule } from "./rules/number";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
 
 export function validateNumber(
@@ -9,8 +10,7 @@ export function validateNumber(
   rules: NumberRule[],
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = value === undefined || value === null;
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(value)) {
     return null;
   }
 

--- a/src/validate/object.spec.ts
+++ b/src/validate/object.spec.ts
@@ -1,0 +1,53 @@
+import { compileSchema } from "../compile/compileSchema";
+
+describe("object", () => {
+  it("always accepts an empty object", () => {
+    const schema = compileSchema(
+      `{ a: string; b: number = 1; c: { d: string }; e: number[]; }`
+    );
+
+    expect(() => schema.parseSync({})).not.toThrow();
+  });
+
+  it("initializes a primitive property that is not provided with null", () => {
+    const schema = compileSchema(`{ a: string }`);
+
+    const parsed = schema.parseSync({});
+
+    expect(parsed.a).toEqual(null);
+  });
+
+  it("initializes object properties that are not provided", () => {
+    const schema = compileSchema(`{ a: {} }`);
+
+    const parsed = schema.parseSync({});
+
+    expect(parsed.a).toEqual({});
+  });
+
+  it("initializes array properties that are not provided", () => {
+    const schema = compileSchema(`{ a: number[] }`);
+
+    const parsed = schema.parseSync({});
+
+    expect(parsed.a).toEqual([]);
+  });
+
+  it("initializes nested object properties that are not provided", () => {
+    const schema = compileSchema(`{ a: { b: string; } }`);
+
+    const parsed = schema.parseSync({});
+
+    expect(parsed.a.b).toEqual(null);
+  });
+
+  it("throws if a non-object value is passed to 'parseSync'", () => {
+    const schema = compileSchema(`{}`);
+
+    expect(() => schema.parseSync(null)).toThrow();
+    expect(() => schema.parseSync("Hello, world")).toThrow();
+    expect(() => schema.parseSync(123)).toThrow();
+    expect(() => schema.parseSync([])).toThrow();
+    expect(() => schema.parseSync(new Map())).toThrow();
+  });
+});

--- a/src/validate/object.ts
+++ b/src/validate/object.ts
@@ -16,7 +16,7 @@ export function validateObject(
     return null;
   }
 
-  const isNotObjectValue = typeof obj !== "object";
+  const isNotObjectValue = Object.prototype !== (obj as any)?.__proto__;
   if (isNotObjectValue) {
     return new ValidationError({
       message: `Expected object value, got ${typeAsString(obj)}`,

--- a/src/validate/object.ts
+++ b/src/validate/object.ts
@@ -4,6 +4,7 @@ import { PropertyNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
 import { validateArray } from "./array";
 import { validatePrimitive } from "./primitive";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { isPlainObject } from "./utils/isPlainObject";
 import { ValidationError } from "./ValidationError";
 
@@ -12,8 +13,7 @@ export function validateObject(
   properties: PropertyNode[],
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = obj === undefined || obj === null;
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(obj)) {
     return null;
   }
 

--- a/src/validate/object.ts
+++ b/src/validate/object.ts
@@ -4,6 +4,7 @@ import { PropertyNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
 import { validateArray } from "./array";
 import { validatePrimitive } from "./primitive";
+import { isPlainObject } from "./utils/isPlainObject";
 import { ValidationError } from "./ValidationError";
 
 export function validateObject(
@@ -16,7 +17,7 @@ export function validateObject(
     return null;
   }
 
-  const isNotObjectValue = Object.prototype !== (obj as any)?.__proto__;
+  const isNotObjectValue = !isPlainObject(obj);
   if (isNotObjectValue) {
     return new ValidationError({
       message: `Expected object value, got ${typeAsString(obj)}`,

--- a/src/validate/primitive.ts
+++ b/src/validate/primitive.ts
@@ -5,6 +5,7 @@ import { ValidationContext } from "../types/ValidationContext";
 import { validateBoolean } from "./boolean";
 import { validateNumber } from "./number";
 import { validateString } from "./string";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
 
 export function validatePrimitive(
@@ -12,9 +13,7 @@ export function validatePrimitive(
   spec: PrimitiveNode,
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = typeof value === "undefined" || value === null;
-
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(value)) {
     value = spec.defaultValue;
   }
 

--- a/src/validate/primitive.ts
+++ b/src/validate/primitive.ts
@@ -12,6 +12,12 @@ export function validatePrimitive(
   spec: PrimitiveNode,
   ctx: ValidationContext
 ): ValidationError | null {
+  const isNullOrUndefined = typeof value === "undefined" || value === null;
+
+  if (isNullOrUndefined) {
+    value = spec.defaultValue;
+  }
+
   const { valueType } = spec;
   switch (valueType) {
     case "string": {

--- a/src/validate/string.ts
+++ b/src/validate/string.ts
@@ -2,6 +2,7 @@ import { typeAsString } from "../format/typeAsString";
 import { StringRule } from "../types/Rule";
 import { ValidationContext } from "../types/ValidationContext";
 import { validateStringRule } from "./rules/string";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
 
 export function validateString(
@@ -9,8 +10,7 @@ export function validateString(
   rules: StringRule[],
   ctx: ValidationContext
 ): ValidationError | null {
-  const isNullOrUndefined = value === undefined || value === null;
-  if (isNullOrUndefined) {
+  if (isNullOrUndefined(value)) {
     return null;
   }
 

--- a/src/validate/utils/isNullOrUndefined.ts
+++ b/src/validate/utils/isNullOrUndefined.ts
@@ -1,0 +1,3 @@
+export function isNullOrUndefined(value: unknown) {
+  return typeof value === "undefined" || value === null;
+}

--- a/src/validate/utils/isPlainObject.ts
+++ b/src/validate/utils/isPlainObject.ts
@@ -1,0 +1,3 @@
+export function isPlainObject(value: unknown) {
+  return value?.constructor === Object;
+}


### PR DESCRIPTION
Closes #14.

This PR implements parsing default values as described in #14.


# Changes

## Add `parseDefaultValue`

```tsx
function parseDefaultValue(state: ParserState, primitiveType: Primitive): unknown
```

It is invoked for primitive values in `parseProperty`:

```tsx
const value = parseValue(state);
const isArray = parseIsArray(state);

if (value.type === "primitive") {
  value.rules = parseRules(state, value.valueType);
  value.defaultValue = parseDefaultValue(state, value.valueType);
}
```


## Add `TokenType.String`

It is used for default string values:

```
{ a: string = "Hello, world" }
```

If a `"` is supposed to be contained within the default value, it can be escaped with a double `\\`:

```
{ a: string = "\\""}
```


## Throw on non-plain objects passed to `parseSync`

```tsx
// in parseSync

if (!isPlainObject(value)) {
  throw new Error(`Expected object, got '${typeAsString(value)}'`);
}
```

## Add tests

Added test for `copyObject` and `parseObject`.