### PR TITLE
Record

### DIFF
--- a/src/ast/astFromString.spec.ts
+++ b/src/ast/astFromString.spec.ts
@@ -63,7 +63,7 @@ describe("astFromString", () => {
 
   it("throws an error for non-primitive property symbols", () => {
     const run = () => astFromString("{a:unknown;}");
-    const errorMessage = `Unknown symbol 'unknown'`;
+    const errorMessage = `Unknown primitive symbol 'unknown'`;
 
     expect(run).toThrow(errorMessage);
   });

--- a/src/ast/parse/property.spec.ts
+++ b/src/ast/parse/property.spec.ts
@@ -126,4 +126,15 @@ describe("parseProperties", () => {
 
     expect(parse).toThrow("Unexpected token '<'");
   });
+
+  it("parses an array of records", () => {
+    const state = new ParserState(`records: Record<string, number>[]`);
+
+    const property = parseProperty(state);
+    const value = property.value as ArrayNode;
+
+    expect(property.key).toEqual("records");
+    expect(value.type).toEqual("array");
+    expect(value.value.type).toEqual("record");
+  });
 });

--- a/src/ast/parse/record.spec.ts
+++ b/src/ast/parse/record.spec.ts
@@ -17,15 +17,6 @@ describe("parseRecord", () => {
     expect(parsed.key.valueType).toEqual("string");
   });
 
-  it("parses a string key", () => {
-    const state = new ParserState(`Record<string, number>`);
-
-    const parsed = parseRecord(state);
-
-    expect(parsed.key.type).toEqual("primitive");
-    expect(parsed.key.valueType).toEqual("string");
-  });
-
   it("parses a number key", () => {
     const state = new ParserState(`Record<number, boolean>`);
 

--- a/src/ast/parse/record.spec.ts
+++ b/src/ast/parse/record.spec.ts
@@ -44,6 +44,14 @@ describe("parseRecord", () => {
     expect(parse).toThrow("Unknown primitive symbol 'symbol'");
   });
 
+  it("does not support key rules", () => {
+    const state = new ParserState(`Record<string <email>, boolean>`);
+
+    const parse = () => parseRecord(state);
+
+    expect(parse).toThrow("Expected ',', got '<'");
+  });
+
   it("parses a primitive value", () => {
     const state = new ParserState(`Record<string, boolean>`);
 

--- a/src/ast/parse/record.spec.ts
+++ b/src/ast/parse/record.spec.ts
@@ -1,0 +1,124 @@
+import {
+  ArrayNode,
+  ObjectNode,
+  PrimitiveNode,
+  RecordNode,
+} from "../../types/Ast";
+import { ParserState } from "../state/ParserState";
+import { parseRecord } from "./record";
+
+describe("parseRecord", () => {
+  it("parses a string key", () => {
+    const state = new ParserState(`Record<string, number>`);
+
+    const parsed = parseRecord(state);
+
+    expect(parsed.key.type).toEqual("primitive");
+    expect(parsed.key.valueType).toEqual("string");
+  });
+
+  it("parses a string key", () => {
+    const state = new ParserState(`Record<string, number>`);
+
+    const parsed = parseRecord(state);
+
+    expect(parsed.key.type).toEqual("primitive");
+    expect(parsed.key.valueType).toEqual("string");
+  });
+
+  it("parses a number key", () => {
+    const state = new ParserState(`Record<number, boolean>`);
+
+    const parsed = parseRecord(state);
+
+    expect(parsed.key.type).toEqual("primitive");
+    expect(parsed.key.valueType).toEqual("number");
+  });
+
+  it("does not support boolean keys", () => {
+    const state = new ParserState(`Record<boolean, boolean>`);
+
+    const parse = () => parseRecord(state);
+
+    expect(parse).toThrow(
+      "Record keys must be either string or number, got 'boolean'"
+    );
+  });
+
+  it("does not support symbol keys", () => {
+    const state = new ParserState(`Record<symbol, boolean>`);
+
+    const parse = () => parseRecord(state);
+
+    expect(parse).toThrow("Unknown primitive symbol 'symbol'");
+  });
+
+  it("parses a primitive value", () => {
+    const state = new ParserState(`Record<string, boolean>`);
+
+    const value = parseRecord(state).value as PrimitiveNode;
+
+    expect(value.type).toEqual("primitive");
+    expect(value.valueType).toEqual("boolean");
+  });
+
+  it("parses rules for primitive values", () => {
+    const state = new ParserState(`Record<string, string <email>>`);
+
+    const value = parseRecord(state).value as PrimitiveNode;
+
+    expect(value.rules.length).toEqual(1);
+  });
+
+  it("parses an array of primitives", () => {
+    const state = new ParserState(`Record<string, number[]>`);
+
+    const arrValue = parseRecord(state).value as ArrayNode;
+    const value = arrValue.value as PrimitiveNode;
+
+    expect(arrValue.type).toEqual("array");
+    expect(value.type).toEqual("primitive");
+    expect(value.valueType).toEqual("number");
+  });
+
+  it("parses rules for an array of primitives", () => {
+    const state = new ParserState(`Record<string, number[] <int, positive>>`);
+
+    const arrValue = parseRecord(state).value as ArrayNode;
+    const value = arrValue.value as PrimitiveNode;
+
+    expect(value.rules.length).toEqual(2);
+  });
+
+  it("parses an object value", () => {
+    const state = new ParserState(`Record<string, { a: string; b: number }>`);
+
+    const value = parseRecord(state).value as ObjectNode;
+
+    expect(value.type).toEqual("object");
+    expect(value.properties.length).toEqual(2);
+  });
+
+  it("parses an array of objects", () => {
+    const state = new ParserState(`Record<string, { a: string }[]>`);
+
+    const arrValue = parseRecord(state).value as ArrayNode;
+    const value = arrValue.value as ObjectNode;
+
+    expect(arrValue.type).toEqual("array");
+    expect(value.type).toEqual("object");
+    expect(value.properties.length).toEqual(1);
+  });
+
+  it("parses a two dimensional Record", () => {
+    const state = new ParserState(`Record<string, Record<number, boolean>>`);
+
+    const record0 = parseRecord(state);
+    const record1 = record0.value as RecordNode;
+    const value = record1.value as PrimitiveNode;
+
+    expect(record0.type).toEqual("record");
+    expect(record1.type).toEqual("record");
+    expect(value.valueType).toEqual("boolean");
+  });
+});

--- a/src/ast/parse/record.ts
+++ b/src/ast/parse/record.ts
@@ -1,0 +1,58 @@
+import { PrimitiveNode, RecordNode } from "../../types/Ast";
+import { ParserState } from "../state/ParserState";
+import { parseArrayableValueAndRules } from "./property";
+import { parseValue } from "./value";
+
+function parseKey(state: ParserState): PrimitiveNode {
+  const value = parseValue(state);
+
+  if (value.type !== "primitive") {
+    throw new Error(
+      `Record keys must be either string or number, got '${value.type}'`
+    );
+  }
+
+  switch (value.valueType) {
+    case "string":
+    case "number":
+      break;
+    default:
+      throw new Error(
+        `Record keys must be either string or number, got '${value.valueType}'`
+      );
+  }
+
+  return value;
+}
+
+export function parseRecord(state: ParserState): RecordNode {
+  if (state.token() !== "Record") {
+    throw new Error(`Unexpected token '${state.token()}'`);
+  }
+
+  state.nextToken();
+
+  if (!state.atDelimeter("<")) {
+    throw new Error(`Expected '<', got '${state.token()}'`);
+  }
+
+  state.nextToken();
+
+  const key = parseKey(state);
+
+  if (!state.atDelimeter(",")) {
+    throw new Error(`Expected ',', got '${state.token()}'`);
+  }
+
+  state.nextToken();
+
+  const value = parseArrayableValueAndRules(state);
+
+  if (!state.atDelimeter(">")) {
+    throw new Error(`Expected '>', got '${state.token()}'`);
+  }
+
+  state.nextToken();
+
+  return { type: "record", key, value };
+}

--- a/src/ast/parse/value.spec.ts
+++ b/src/ast/parse/value.spec.ts
@@ -63,7 +63,7 @@ describe("parseValue", () => {
 
     const parse = () => parseValue(state);
 
-    expect(parse).toThrow(`Unknown symbol 'unknown'`);
+    expect(parse).toThrow(`Unknown primitive symbol 'unknown'`);
   });
 
   it("throws on unexpected delimeters", () => {

--- a/src/ast/parse/value.ts
+++ b/src/ast/parse/value.ts
@@ -4,6 +4,7 @@ import { parseObject } from "./object";
 import { ParserState } from "../state/ParserState";
 import { TokenType } from "../token";
 import { PrimitivesTuple } from "../../types/Primitive";
+import { parseRecord } from "./record";
 
 const primitiveList: PrimitivesTuple = ["string", "number", "boolean"];
 const primitives = new Set(primitiveList);
@@ -21,8 +22,13 @@ export function parseValue(state: ParserState): ValueNode {
   switch (tokenType) {
     case TokenType.Symbol: {
       const token = state.token();
+
+      if (token === "Record") {
+        return parseRecord(state);
+      }
+
       if (!isPrimitiveSymbol(token)) {
-        throw new Error(`Unknown symbol '${token}'`);
+        throw new Error(`Unknown primitive symbol '${token}'`);
       }
       value = {
         type: "primitive",

--- a/src/copy/copyObject.spec.ts
+++ b/src/copy/copyObject.spec.ts
@@ -171,7 +171,6 @@ describe("copyObject", () => {
 
   it("creates new objects for record properties", () => {
     const ast = astFromString(`{ map: Record<string, { value: number }> }`);
-
     const obj = { value: 42 };
 
     const copied: any = copyObject({ map: { obj } }, ast);
@@ -182,14 +181,12 @@ describe("copyObject", () => {
 
   it("omits null or undefined properties for records", () => {
     const ast = astFromString(`{ map: Record<string, number> }`);
+    const map = { a: 1, b: null, c: undefined };
 
-    const { map } = copyObject(
-      { map: { a: 1, b: null, c: undefined } },
-      ast
-    ) as any;
+    const copied = copyObject({ map }, ast) as any;
 
-    expect(map).toHaveProperty("a");
-    expect(map).not.toHaveProperty("b");
-    expect(map).not.toHaveProperty("c");
+    expect(copied.map).toHaveProperty("a");
+    expect(copied.map).not.toHaveProperty("b");
+    expect(copied.map).not.toHaveProperty("c");
   });
 });

--- a/src/copy/copyObject.spec.ts
+++ b/src/copy/copyObject.spec.ts
@@ -152,4 +152,31 @@ describe("copyObject", () => {
 
     expect(copied.obj).toEqual({ value: 42 });
   });
+
+  it("initializes records to an empty object if not provided", () => {
+    const ast = astFromString(`{ map: Record<string, {}> }`);
+
+    const copied: any = copyObject({}, ast);
+
+    expect(copied).toEqual({ map: {} });
+  });
+
+  it("copies the elements of a record", () => {
+    const ast = astFromString(`{ map: Record<string, number> }`);
+
+    const copied: any = copyObject({ map: { a: 1, b: 2, c: 3 } }, ast);
+
+    expect(copied.map).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("creates new objects for record properties", () => {
+    const ast = astFromString(`{ map: Record<string, { value: number }> }`);
+
+    const obj = { value: 42 };
+
+    const copied: any = copyObject({ map: { obj } }, ast);
+
+    expect(copied.map.obj).toEqual(obj);
+    expect(copied.map.obj === obj).toEqual(false);
+  });
 });

--- a/src/copy/copyObject.spec.ts
+++ b/src/copy/copyObject.spec.ts
@@ -179,4 +179,17 @@ describe("copyObject", () => {
     expect(copied.map.obj).toEqual(obj);
     expect(copied.map.obj === obj).toEqual(false);
   });
+
+  it("omits null or undefined properties for records", () => {
+    const ast = astFromString(`{ map: Record<string, number> }`);
+
+    const { map } = copyObject(
+      { map: { a: 1, b: null, c: undefined } },
+      ast
+    ) as any;
+
+    expect(map).toHaveProperty("a");
+    expect(map).not.toHaveProperty("b");
+    expect(map).not.toHaveProperty("c");
+  });
 });

--- a/src/copy/copyObject.ts
+++ b/src/copy/copyObject.ts
@@ -41,6 +41,8 @@ export function copyRecord(record: unknown, ast: RecordNode): unknown {
   const out: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(record || {})) {
+    if (isNullOrUndefined(value)) continue;
+
     out[key] = copyProperty(value, ast.value);
   }
 

--- a/src/copy/copyObject.ts
+++ b/src/copy/copyObject.ts
@@ -1,5 +1,5 @@
 import { enforceExhaustive } from "../switch";
-import { ArrayNode, ObjectNode, ValueNode } from "../types/Ast";
+import { ArrayNode, ObjectNode, RecordNode, ValueNode } from "../types/Ast";
 import { isNullOrUndefined } from "../validate/utils/isNullOrUndefined";
 
 function copyProperty(value: unknown, ast: ValueNode): unknown {
@@ -12,6 +12,8 @@ function copyProperty(value: unknown, ast: ValueNode): unknown {
       return copyObject(value || {}, ast);
     case "array":
       return copyArray((value as unknown[]) || [], ast);
+    case "record":
+      return copyRecord((value as unknown[]) || [], ast);
     default:
       enforceExhaustive(type, "Unexpected type");
   }
@@ -33,4 +35,14 @@ export function copyObject(object: unknown, ast: ObjectNode): unknown {
   }
 
   return to;
+}
+
+export function copyRecord(record: unknown, ast: RecordNode): unknown {
+  const out: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(record || {})) {
+    out[key] = copyProperty(value, ast.value);
+  }
+
+  return out;
 }

--- a/src/types/Ast.ts
+++ b/src/types/Ast.ts
@@ -19,11 +19,17 @@ export interface ObjectNode {
   properties: PropertyNode[];
 }
 
+export interface RecordNode {
+  type: "record";
+  key: PrimitiveNode;
+  value: ValueNode;
+}
+
 export interface ArrayNode {
   type: "array";
   value: ValueNode;
 }
 
-export type ValueNode = PrimitiveNode | ArrayNode | ObjectNode;
+export type ValueNode = PrimitiveNode | ArrayNode | ObjectNode | RecordNode;
 
 export type Ast = ObjectNode;

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -121,6 +121,25 @@ it("parses multiple object properties", () => [
   >(),
 ]);
 
+it("parses records", () => [
+  eq<Parse<`{ a: Record<string, number> }`>, { a: Record<string, number> }>(),
+  eq<
+    Parse<`{ a: Record<string, { value: number }> }`>,
+    { a: Record<string, { value: number | null }> }
+  >(),
+]);
+
+it("records of records", () => [
+  eq<
+    Parse<`{ a: Record<string, Record<number, boolean>> }`>,
+    { a: Record<string, Record<number, boolean>> }
+  >(),
+  eq<
+    Parse<`{ a: Record<string, { a: Record<number, { b: boolean }>}> }`>,
+    { a: Record<string, { a: Record<number, { b: boolean | null }> }> }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -140,6 +140,13 @@ it("parses records of records", () => [
   >(),
 ]);
 
+it("parses records of primitives with rules", () => [
+  eq<
+    Parse<`{ a: Record<string, string <email>>; b: string; }`>,
+    { a: Record<string, string>; b: string | null }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -129,7 +129,7 @@ it("parses records", () => [
   >(),
 ]);
 
-it("records of records", () => [
+it("parses records of records", () => [
   eq<
     Parse<`{ a: Record<string, Record<number, boolean>> }`>,
     { a: Record<string, Record<number, boolean>> }

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -147,6 +147,13 @@ it("parses records of primitives with rules", () => [
   >(),
 ]);
 
+it("parses records of objects with primitives with rules", () => [
+  eq<
+    Parse<`{ a: Record<string, { email: string <email> }>; b: string; }`>,
+    { a: Record<string, { email: string | null }>; b: string | null }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -81,6 +81,18 @@ type OnMatchedObjectPropertyDuringSplit<
   After extends string
 > = OnMatchedWrappedProperty<Before, InObject, After, StringWrapper<"{", "}">>;
 
+type OnMatchedRecordOfObjectsPropertyDuringSplit<
+  Before extends string,
+  InObject extends string,
+  After extends string,
+  K extends string
+> = OnMatchedWrappedProperty<
+  Before,
+  InObject,
+  After,
+  StringWrapper<`Record<${K},{`, "}>">
+>;
+
 type OnMatchedArrayOfObjectsPropertyDuringSplit<
   Before extends string,
   InObject extends string,
@@ -109,15 +121,28 @@ type OnMatchedWrappedProperty<
 
 type _SplitIntoProperties<T extends string> =
   //
-  // Attempt to match an array of objects (named Array syntax), for example:
+  // Attempt to match a Record of objects:
   //
-  //    `a:Array<{b:string}>;c:number`
+  //    `a:Record<string,{b:string}>;c:number`
   //
   //    Before:   `a:`
   //    InObject: `b:string`
   //    After:    `c:number`
   //
-  T extends `${infer Before}Array<{${infer InObject}}>${infer After}` //
+  T extends `${infer Before}Record<${infer K extends
+    | "string"
+    | "number"},{${infer InObject}}>${infer After}` //
+    ? OnMatchedRecordOfObjectsPropertyDuringSplit<Before, InObject, After, K>
+    : //
+    // Attempt to match an array of objects (named Array syntax), for example:
+    //
+    //    `a:Array<{b:string}>;c:number`
+    //
+    //    Before:   `a:`
+    //    InObject: `b:string`
+    //    After:    `c:number`
+    //
+    T extends `${infer Before}Array<{${infer InObject}}>${infer After}` //
     ? OnMatchedArrayOfObjectsPropertyDuringSplit<Before, InObject, After>
     : //
     // Attempt to match an array of objects (literal array syntax), for example:

--- a/src/types/SplitIntoProperties.typecheck.ts
+++ b/src/types/SplitIntoProperties.typecheck.ts
@@ -65,4 +65,11 @@ it("splits a record correctly", () => [
   >(),
 ]);
 
+it("splits a record of primitives with rules correctly", () => [
+  eq<
+    SplitIntoProperties<`a:Record<string,string<email>>;b:string;`>,
+    ["a:Record<string,string<email>>", "b:string"]
+  >(),
+]);
+
 /** @todo test error cases */

--- a/src/types/SplitIntoProperties.typecheck.ts
+++ b/src/types/SplitIntoProperties.typecheck.ts
@@ -58,4 +58,11 @@ it("does not split nested object properties", () => [
   >(),
 ]);
 
+it("splits a record correctly", () => [
+  eq<
+    SplitIntoProperties<`a:Record<string,{b:number}>;c:number`>,
+    [`a:Record<string,{b:number}>`, `c:number`]
+  >(),
+]);
+
 /** @todo test error cases */

--- a/src/validate/array.ts
+++ b/src/validate/array.ts
@@ -1,11 +1,9 @@
 import { typeAsString } from "../format/typeAsString";
-import { enforceExhaustive } from "../switch";
 import { ArrayNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
-import { validateObject } from "./object";
-import { validatePrimitive } from "./primitive";
 import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { ValidationError } from "./ValidationError";
+import { validateValue } from "./value";
 
 export function validateArray(
   arr: unknown[],
@@ -30,26 +28,9 @@ export function validateArray(
     ctx.path.push(`[${i}]`);
 
     const value = arr[i];
-    const { type } = spec.value;
-    switch (type) {
-      case "object": {
-        const err = validateObject(value, spec.value.properties, ctx);
-        if (err) return err;
-        break;
-      }
-      case "array": {
-        const err = validateArray(value, spec.value, ctx);
-        if (err) return err;
-        break;
-      }
-      case "primitive": {
-        const err = validatePrimitive(value, spec.value, ctx);
-        if (err) return err;
-        break;
-      }
-      default:
-        enforceExhaustive(type, "Unexpected value type");
-    }
+
+    const err = validateValue(value, spec.value, ctx);
+    if (err) return err;
 
     ctx.path.pop();
   }

--- a/src/validate/object.ts
+++ b/src/validate/object.ts
@@ -1,12 +1,10 @@
 import { typeAsString } from "../format/typeAsString";
-import { enforceExhaustive } from "../switch";
 import { PropertyNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
-import { validateArray } from "./array";
-import { validatePrimitive } from "./primitive";
 import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { isPlainObject } from "./utils/isPlainObject";
 import { ValidationError } from "./ValidationError";
+import { validateValue } from "./value";
 
 export function validateObject(
   obj: unknown,
@@ -26,30 +24,13 @@ export function validateObject(
     });
   }
 
-  for (const { key, value: valueSpec } of properties) {
-    ctx.path.push(key);
+  for (const property of properties) {
+    ctx.path.push(property.key);
 
-    const { type } = valueSpec;
-    const value = (obj as Record<string, unknown>)[key];
-    switch (type) {
-      case "object": {
-        const err = validateObject(value, valueSpec.properties, ctx);
-        if (err) return err;
-        break;
-      }
-      case "array": {
-        const err = validateArray(value as unknown[], valueSpec, ctx);
-        if (err) return err;
-        break;
-      }
-      case "primitive": {
-        const err = validatePrimitive(value, valueSpec, ctx);
-        if (err) return err;
-        break;
-      }
-      default:
-        enforceExhaustive(type, "Unexpected value type");
-    }
+    const value = (obj as Record<string, unknown>)[property.key];
+
+    const err = validateValue(value, property.value, ctx);
+    if (err) return err;
 
     ctx.path.pop();
   }

--- a/src/validate/record.spec.ts
+++ b/src/validate/record.spec.ts
@@ -3,8 +3,32 @@ import { compileSchema } from "../compile/compileSchema";
 describe("validateRecord", () => {
   it("validates a primitive record", () => {
     const schema = compileSchema(`{ map: Record<string, number> }`);
-
     const map = { a: 1, b: 2, c: 3 };
+
+    expect(() => schema.parseSync({ map })).not.toThrow();
+  });
+
+  it("rejects non-numeric keys when the key type is numeric", () => {
+    const schema = compileSchema(`{ map: Record<number, string> }`);
+    const map = { 1: "a", 2: "b", three: "c" };
+
+    expect(() => schema.parseSync({ map })).toThrow(
+      "Expected numeric key, got 'three'"
+    );
+  });
+
+  it("rejects non-numeric keys that pass parseInt", () => {
+    const schema = compileSchema(`{ map: Record<number, string> }`);
+    const map = { 1: "a", 2: "b", "3a": "c" };
+
+    expect(() => schema.parseSync({ map })).toThrow(
+      "Expected numeric key, got '3a'"
+    );
+  });
+
+  it("accepts floats as numeric keys", () => {
+    const schema = compileSchema(`{ map: Record<number, string> }`);
+    const map = { 1: "a", 2: "b", "3.1": "c" };
 
     expect(() => schema.parseSync({ map })).not.toThrow();
   });

--- a/src/validate/record.spec.ts
+++ b/src/validate/record.spec.ts
@@ -1,0 +1,11 @@
+import { compileSchema } from "../compile/compileSchema";
+
+describe("validateRecord", () => {
+  it("validates a primitive record", () => {
+    const schema = compileSchema(`{ map: Record<string, number> }`);
+
+    const map = { a: 1, b: 2, c: 3 };
+
+    expect(() => schema.parseSync({ map })).not.toThrow();
+  });
+});

--- a/src/validate/record.ts
+++ b/src/validate/record.ts
@@ -1,0 +1,48 @@
+import { typeAsString } from "../format/typeAsString";
+import { RecordNode } from "../types/Ast";
+import { ValidationContext } from "../types/ValidationContext";
+import { validatePrimitive } from "./primitive";
+import { isNullOrUndefined } from "./utils/isNullOrUndefined";
+import { isPlainObject } from "./utils/isPlainObject";
+import { ValidationError } from "./ValidationError";
+import { validateValue } from "./value";
+
+export function validateRecord(
+  record: unknown,
+  spec: RecordNode,
+  ctx: ValidationContext
+): ValidationError | null {
+  if (isNullOrUndefined(record)) {
+    return null;
+  }
+
+  const isNotObjectValue = !isPlainObject(record);
+  if (isNotObjectValue) {
+    return new ValidationError({
+      message: `Expected object value, got ${typeAsString(record)}`,
+      value: record,
+      ctx,
+    });
+  }
+
+  const entries = Object.entries(record as {});
+
+  for (const [_key, value] of entries) {
+    ctx.path.push(_key);
+
+    let key = _key as string | number;
+    if (spec.key.valueType === "number") {
+      key = Number(key);
+    }
+
+    const keyErr = validatePrimitive(key, spec.key, ctx);
+    if (keyErr) return keyErr;
+
+    const valueErr = validateValue(value, spec.value, ctx);
+    if (valueErr) return valueErr;
+
+    ctx.path.pop();
+  }
+
+  return null;
+}

--- a/src/validate/record.ts
+++ b/src/validate/record.ts
@@ -1,7 +1,6 @@
 import { typeAsString } from "../format/typeAsString";
 import { RecordNode } from "../types/Ast";
 import { ValidationContext } from "../types/ValidationContext";
-import { validatePrimitive } from "./primitive";
 import { isNullOrUndefined } from "./utils/isNullOrUndefined";
 import { isPlainObject } from "./utils/isPlainObject";
 import { ValidationError } from "./ValidationError";
@@ -27,16 +26,19 @@ export function validateRecord(
 
   const entries = Object.entries(record as {});
 
-  for (const [_key, value] of entries) {
-    ctx.path.push(_key);
+  for (const [key, value] of entries) {
+    ctx.path.push(key);
 
-    let key = _key as string | number;
     if (spec.key.valueType === "number") {
-      key = Number(key);
+      const keyAsNumber = Number(key);
+      if (!Number.isFinite(keyAsNumber)) {
+        return new ValidationError({
+          message: `Expected numeric key, got '${key}'`,
+          value: key,
+          ctx,
+        });
+      }
     }
-
-    const keyErr = validatePrimitive(key, spec.key, ctx);
-    if (keyErr) return keyErr;
 
     const valueErr = validateValue(value, spec.value, ctx);
     if (valueErr) return valueErr;

--- a/src/validate/value.ts
+++ b/src/validate/value.ts
@@ -1,0 +1,39 @@
+import { enforceExhaustive } from "../switch";
+import { ValueNode } from "../types/Ast";
+import { ValidationContext } from "../types/ValidationContext";
+import { validateArray } from "./array";
+import { validateObject } from "./object";
+import { validatePrimitive } from "./primitive";
+import { validateRecord } from "./record";
+
+export function validateValue(
+  value: unknown,
+  valueSpec: ValueNode,
+  ctx: ValidationContext
+) {
+  const { type } = valueSpec;
+  switch (type) {
+    case "object": {
+      const err = validateObject(value, valueSpec.properties, ctx);
+      if (err) return err;
+      break;
+    }
+    case "array": {
+      const err = validateArray(value as unknown[], valueSpec, ctx);
+      if (err) return err;
+      break;
+    }
+    case "primitive": {
+      const err = validatePrimitive(value, valueSpec, ctx);
+      if (err) return err;
+      break;
+    }
+    case "record": {
+      const err = validateRecord(value, valueSpec, ctx);
+      if (err) return err;
+      break;
+    }
+    default:
+      enforceExhaustive(type, "Unexpected value type");
+  }
+}


### PR DESCRIPTION
Closes #20 

# Changes

## Add support for `Record<K, T>`

`K` can be either `string` or `number`. `T` can be any value, such as `string`, `{}`, `number[]`, `{}[]` or `Record<string, boolean>[]`.

The emitted interface given a `Record<string, string>` template is `Record<string, string>`, as opposed to `Record<string, string | null>`. This is because `null` and `undefined` values are not copied:

```tsx
it("omits null or undefined properties for records", () => {
  const ast = astFromString(`{ map: Record<string, number> }`);
  const map = { a: 1, b: null, c: undefined };

  const copied = copyObject({ map }, ast) as any;

  expect(copied.map).toHaveProperty("a");
  expect(copied.map).not.toHaveProperty("b");
  expect(copied.map).not.toHaveProperty("c");
});
```