### PR TITLE
N dimensional arrays

### DIFF
--- a/src/types/Parse.ts
+++ b/src/types/Parse.ts
@@ -41,11 +41,11 @@ type FindValue<T extends string, NotNull = false> =
     : //
     // Array of primitives (without rules)
     T extends `${infer Token}[]`
-    ? ParseToken<Token>[]
+    ? FindValue<Token, true>[]
     : //
     // Array of primitives (with rules)
     T extends `${infer Token}[]<${string}>`
-    ? ParseToken<Token>[]
+    ? FindValue<Token, true>[]
     : //
     // Primitive with rules and a default
     T extends `${infer Token}<${string}>=${string}`

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -97,13 +97,10 @@ it("parses objects as properties", () => [eq<Parse<`{ a: {} }`>, { a: {} }>()]);
 
 it("parses arrays of objects as properties", () => [
   // Array literal syntax
-  eq<Parse<`{ a: { b: number }[] }`>, { a: Array<{ b: number | null }> }>(),
+  eq<Parse<`{ a: { b: number }[] }`>, { a: { b: number | null }[] }>(),
 
   // Named array syntax
-  eq<
-    Parse<`{ a: Array<{ b: number }> }`>,
-    { a: Array<{ b: number | null }> }
-  >(),
+  eq<Parse<`{ a: { b: number }[] }`>, { a: Array<{ b: number | null }> }>(),
 ]);
 
 it("parses nested object properties", () => [
@@ -154,8 +151,9 @@ it("parses records of objects with primitives with rules", () => [
   >(),
 ]);
 
-it("parses two-dimensional arrays", () => [
+it("parses N-dimensional arrays of primitives", () => [
   eq<Parse<`{ a: number[][] }`>, { a: number[][] }>(),
+  eq<Parse<`{ a: number[][][][] }`>, { a: number[][][][] }>(),
 ]);
 
 it("errors when an invalid symbol is provided for a property value", () => {
@@ -173,5 +171,5 @@ it("returns a helpful error message if a key is not properly specified", () => [
     CompileError<["Expected key in format '<key>:', got 'a'"]>
   >(),
   eq<Parse<`{{}}`>, CompileError<["Expected a key before '{}'"]>>(),
-  eq<Parse<`{{}[]}`>, CompileError<["Expected a key before 'Array<{}>'"]>>(),
+  eq<Parse<`{{}[]}`>, CompileError<["Expected a key before '{}[]'"]>>(),
 ]);

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -100,7 +100,7 @@ it("parses arrays of objects as properties", () => [
   eq<Parse<`{ a: { b: number }[] }`>, { a: { b: number | null }[] }>(),
 
   // Named array syntax
-  eq<Parse<`{ a: { b: number }[] }`>, { a: Array<{ b: number | null }> }>(),
+  eq<Parse<`{ a: { b: number }[] }`>, { a: { b: number | null }[] }>(),
 ]);
 
 it("parses nested object properties", () => [

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -156,6 +156,22 @@ it("parses N-dimensional arrays of primitives", () => [
   eq<Parse<`{ a: number[][][][] }`>, { a: number[][][][] }>(),
 ]);
 
+it("parses N-dimensional arrays of objects", () => [
+  eq<Parse<`{ a: { a:string; }[][] }`>, { a: { a: string | null }[][] }>(),
+  eq<
+    Parse<`{ a: { a:string; }[][][][] }`>,
+    { a: { a: string | null }[][][][] }
+  >(),
+]);
+
+it("parses nested N-dimensional arrays", () => [
+  eq<Parse<`{ a: { a:string; }[][] }`>, { a: { a: string | null }[][] }>(),
+  eq<
+    Parse<`{ a: { b:string = "Hello"; c: { d: number[][][] }[] }[][]; b: string[][]; }`>,
+    { a: { b: string; c: { d: number[][][] }[] }[][]; b: string[][] }
+  >(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/Parse.typecheck.ts
+++ b/src/types/Parse.typecheck.ts
@@ -154,6 +154,10 @@ it("parses records of objects with primitives with rules", () => [
   >(),
 ]);
 
+it("parses two-dimensional arrays", () => [
+  eq<Parse<`{ a: number[][] }`>, { a: number[][] }>(),
+]);
+
 it("errors when an invalid symbol is provided for a property value", () => {
   type Err = [
     "Failed to parse value of property 'a'",

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -101,7 +101,7 @@ type OnMatchedArrayOfObjectsPropertyDuringSplit<
   Before,
   InObject,
   After,
-  StringWrapper<"Array<{", "}>">
+  StringWrapper<"{", "}[]">
 >;
 
 type OnMatchedWrappedProperty<

--- a/src/types/SplitIntoProperties.ts
+++ b/src/types/SplitIntoProperties.ts
@@ -75,12 +75,6 @@ type StringAsTuple<T extends string> = T extends ""
 
 type StringLength<T extends string> = StringAsTuple<T>["length"];
 
-type OnMatchedObjectPropertyDuringSplit<
-  Before extends string,
-  InObject extends string,
-  After extends string
-> = OnMatchedWrappedProperty<Before, InObject, After, StringWrapper<"{", "}">>;
-
 type OnMatchedRecordOfObjectsPropertyDuringSplit<
   Before extends string,
   InObject extends string,
@@ -93,15 +87,16 @@ type OnMatchedRecordOfObjectsPropertyDuringSplit<
   StringWrapper<`Record<${K},{`, "}>">
 >;
 
-type OnMatchedArrayOfObjectsPropertyDuringSplit<
+type OnMatchedObjectPropertyDuringSplit<
   Before extends string,
   InObject extends string,
-  After extends string
+  After extends string,
+  Arrays extends string
 > = OnMatchedWrappedProperty<
   Before,
   InObject,
   After,
-  StringWrapper<"{", "}[]">
+  StringWrapper<"{", `}${Arrays}`>
 >;
 
 type OnMatchedWrappedProperty<
@@ -134,45 +129,36 @@ type _SplitIntoProperties<T extends string> =
     | "number"},{${infer InObject}}>${infer After}` //
     ? OnMatchedRecordOfObjectsPropertyDuringSplit<Before, InObject, After, K>
     : //
-    // Attempt to match an array of objects (named Array syntax), for example:
+    // Match an object (0-N dimensional array) property with an additional property
+    // after it, for example:
     //
-    //    `a:Array<{b:string}>;c:number`
-    //
-    //    Before:   `a:`
-    //    InObject: `b:string`
-    //    After:    `c:number`
-    //
-    T extends `${infer Before}Array<{${infer InObject}}>${infer After}` //
-    ? OnMatchedArrayOfObjectsPropertyDuringSplit<Before, InObject, After>
-    : //
-    // Attempt to match an array of objects (literal array syntax), for example:
-    //
-    //    `a:{b:string}[];c:number`
+    //    `a:{b:string}[][];c:number`
     //
     //    Before:   `a:`
     //    InObject: `b:string`
     //    After:    `c:number`
+    //    Arrays:   `[][]`
     //
-    T extends `${infer Before}{${infer InObject}}[]${infer After}`
-    ? OnMatchedArrayOfObjectsPropertyDuringSplit<Before, InObject, After>
+    T extends `${infer Before}{${infer InObject}}${infer Arrays};${infer After}`
+    ? OnMatchedObjectPropertyDuringSplit<Before, InObject, After, Arrays>
     : //
-    // Attempt to match an object property, for example:
+    // Attempt to match object (0-N dimensional array) with no additional
+    // properties, for example:
     //
-    //    `a:{b:string};c:number`
-    //
-    // This gets split into:
+    //    `a:{b:string}[][]`
     //
     //    Before:   `a:`
     //    InObject: `b:string`
-    //    After:    `c:number`
+    //    Arrays:   `[][]`
     //
-    T extends `${infer Before}{${infer InObject}}${infer After}`
-    ? OnMatchedObjectPropertyDuringSplit<Before, InObject, After>
+    T extends `${infer Before}{${infer InObject}}${infer Arrays}`
+    ? OnMatchedObjectPropertyDuringSplit<Before, InObject, "", Arrays>
     : //
-    // We did not match any array or object syntaxes:
+    // We did not match any special cases:
     //
+    //    `key:Record<K, {...}>`
     //    `key:primitive[]`
-    //    `key:Array<{...}>`
+    //    `key:{...}`
     //    `key:{...}[]`
     //
     // This means that we are only dealing with primitives in the form:

--- a/src/types/SplitIntoProperties.typecheck.ts
+++ b/src/types/SplitIntoProperties.typecheck.ts
@@ -46,15 +46,48 @@ it("does not split properties if ';' is not used by a separator", () => [
 it("does not split nested object properties", () => [
   eq<
     SplitIntoProperties<`a:{b:{c:{}}};d:string;e:{}`>,
-    [`a:{b:{c:{};}}`, `d:string`, `e:{}`]
+    [`a:{b:{c:{}}}`, `d:string`, `e:{}`]
   >(),
   eq<
     SplitIntoProperties<`a:{b:{c:{};d:{};e:{}}}`>,
-    [`a:{b:{c:{};d:{};e:{};}}`]
+    [`a:{b:{c:{};d:{};e:{}}}`]
   >(),
   eq<
     SplitIntoProperties<`a:{b:{c:{}}}[];d:string;e:{}`>,
-    [`a:Array<{b:{c:{}}}>`, `d:string`, `e:{}`]
+    [`a:{b:{c:{}}}[]`, `d:string`, `e:{}`]
+  >(),
+]);
+
+it("splits N-dimensional arrays of objects", () => [
+  eq<SplitIntoProperties<`a:string;b:{}[][]`>, [`a:string`, `b:{}[][]`]>(),
+  eq<SplitIntoProperties<`a:{}[][];b:string`>, [`a:{}[][]`, `b:string`]>(),
+  eq<
+    SplitIntoProperties<`a:{}[][];b:string;c:{}[][]`>,
+    [`a:{}[][]`, `b:string`, `c:{}[][]`]
+  >(),
+  eq<
+    SplitIntoProperties<`a:{}[];b:string[][];c:{}[][]`>,
+    [`a:{}[]`, `b:string[][]`, `c:{}[][]`]
+  >(),
+]);
+
+it("splits N-dimensional arrays of objects with object properties", () => [
+  eq<SplitIntoProperties<`a:{b:{}[]}[];c:{}`>, ["a:{b:{}[]}[]", "c:{}"]>(),
+  eq<
+    SplitIntoProperties<`a:string;b:{c:{}[][]}[][];d:{}[][]`>,
+    [`a:string`, `b:{c:{}[][]}[][]`, `d:{}[][]`]
+  >(),
+  eq<
+    SplitIntoProperties<`a:string;b:{c:number[][]<int>}[][];g:{}[][]`>,
+    [`a:string`, `b:{c:number[][]<int>}[][]`, `g:{}[][]`]
+  >(),
+  eq<
+    SplitIntoProperties<`a:string;b:{c:{d:number[]<int>;e:{f:string[]<email>}[]}[]}[];g:{}[]`>,
+    [
+      `a:string`,
+      `b:{c:{d:number[]<int>;e:{f:string[]<email>}[]}[]}[]`,
+      `g:{}[]`
+    ]
   >(),
 ]);
 

--- a/src/validate/array.spec.ts
+++ b/src/validate/array.spec.ts
@@ -65,4 +65,21 @@ describe("validateArray", () => {
       expect(parse(value)).not.toThrow();
     }
   });
+
+  it("rejects invalud values for a two-dimensional array of primitives", () => {
+    const parse = createParseFunction(`number[][] <positive>`);
+    const numberArrays = [
+      [
+        [0, 1],
+        [1, "5"],
+      ],
+      [1, 2, 3],
+      [[-1, 0]],
+      [[[-1, 0]]],
+    ];
+
+    for (const value of numberArrays) {
+      expect(parse(value)).toThrow();
+    }
+  });
 });

--- a/src/validate/array.spec.ts
+++ b/src/validate/array.spec.ts
@@ -47,4 +47,22 @@ describe("validateArray", () => {
       expect(parse(value)).toThrow();
     }
   });
+
+  it("accepts a two-dimensional array of primitives of the correct type", () => {
+    const parse = createParseFunction(`number[][]`);
+    const numberArrays = [
+      [
+        [0, 1],
+        [1, 1],
+        [1, 0],
+        [0, 0],
+      ],
+      [],
+      [[9999, 23123]],
+    ];
+
+    for (const value of numberArrays) {
+      expect(parse(value)).not.toThrow();
+    }
+  });
 });

--- a/src/validate/array.spec.ts
+++ b/src/validate/array.spec.ts
@@ -1,0 +1,50 @@
+import { compileSchema } from "../compile/compileSchema";
+
+describe("validateArray", () => {
+  function createParseFunction<T extends string>(s: T) {
+    const schema = compileSchema(`{ value: ${s}; }`);
+    const parse = (value: unknown) => () => schema.parseSync({ value });
+    return parse;
+  }
+
+  it("accepts an array of primitives of the correct type", () => {
+    const parse = createParseFunction(`number[]`);
+    const numberArrays = [[-1, 0, 1], [], [50]];
+
+    for (const value of numberArrays) {
+      expect(parse(value)).not.toThrow();
+    }
+  });
+
+  it("rejects arrays with invalid values", () => {
+    const parse = createParseFunction(`number[]`);
+    const notNumberArrays = [[-1, 0, "1"], [Infinity], [[]], [1, {}], ["1"]];
+
+    for (const value of notNumberArrays) {
+      expect(parse(value)).toThrow();
+    }
+  });
+
+  it("accepts arrays of objects that match the object schema", () => {
+    const parse = createParseFunction(`{ val: number <positive> }[]`);
+    const validArrays = [[{ val: 0 }, { val: 1 }], [], [{ val: 1000 }]];
+
+    for (const value of validArrays) {
+      expect(parse(value)).not.toThrow();
+    }
+  });
+
+  it("rejects arrays of objects that do not match the object schema", () => {
+    const parse = createParseFunction(`{ val: number <positive> }[]`);
+    const validArrays = [
+      [{ val: 0 }, { val: 1 }, { val: "2" }],
+      [50],
+      [{ val: -1 }],
+      [{ val: [] }],
+    ];
+
+    for (const value of validArrays) {
+      expect(parse(value)).toThrow();
+    }
+  });
+});

--- a/src/validate/utils/callNTimes.spec.ts
+++ b/src/validate/utils/callNTimes.spec.ts
@@ -1,0 +1,36 @@
+import { callNTimes } from "./callNTimes";
+
+describe("callNTimes", () => {
+  it("calls a function N times", () => {
+    let result = 0;
+
+    callNTimes(5, () => result++);
+
+    expect(result).toEqual(5);
+  });
+
+  it("throws on non-finite number values", () => {
+    const invalidValues = [NaN, Infinity, -Infinity];
+
+    for (const value of invalidValues) {
+      expect(() => callNTimes(value, () => {})).toThrow();
+    }
+  });
+
+  it("ignores negative values", () => {
+    let result = 0;
+
+    callNTimes(-5, () => result++);
+
+    expect(result).toEqual(0);
+  });
+
+  it("throws on non-numeric number values", () => {
+    const invalidValues = ["0", {}, [], null];
+
+    for (const value of invalidValues) {
+      // @ts-expect-error
+      expect(() => callNTimes(value, () => {})).toThrow();
+    }
+  });
+});

--- a/src/validate/utils/callNTimes.ts
+++ b/src/validate/utils/callNTimes.ts
@@ -1,0 +1,9 @@
+export function callNTimes(n: number, callback: () => void) {
+  if (!Number.isFinite(n)) {
+    throw new Error(`Expected valid number, got '${n}'`);
+  }
+  if (n < 0) return;
+  for (let i = 0; i < n; i++) {
+    callback();
+  }
+}


### PR DESCRIPTION
Closes #18 

The following is now a valid template:

```
{ a: number[][]; b: { value: string }[][][] }
```

that resolves to:

```tsx
{ a: number[][]; b: { value: string | null }[][][] }
```

# Changes

## Disallow `Array<...>` syntax

Supporting two ways of declaring arrays just added complexity. The array literal notation is now the only way to declare an array.

This is a breaking change, but as we have not released this package publicly we are making it lightly.