### PR TITLE
Add backlink to the blog post that explains the concept of this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
   Experimental schema builder using TypeScript template strings.
 </p>
 
+## Concept
+
+The concept of how this library works is explained in the blog post [Build your own schema language with TypeScript's infer keyword](https://alexharri.com/blog/build-schema-language-with-infer)
 
 ## Usage
 


### PR DESCRIPTION
Add backlink to blog post that explains the concept of this library

I wanted to remember the link to your blog post and thought that just starring this repo is ideal, and that there must be a back link. Unfortunately there was none. But also in general I think that it would be nice to have a backreference in the readme.